### PR TITLE
add ruff line-length setting for VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "ruff.lineLength": 100,
+}


### PR DESCRIPTION
This might be a PR for nobody but me, but this makes VS Code's `ruff` integration work with our line length setting for `black` (so I'm not accidentally reformatting every file I touch)