### PR TITLE
Allow the Map primitive to get a reference to a Callable

### DIFF
--- a/py/sentry_streams/flink/flink_adapter.py
+++ b/py/sentry_streams/flink/flink_adapter.py
@@ -13,7 +13,7 @@ from pyflink.datastream.connectors.kafka import (
 
 from sentry_streams.adapters.stream_adapter import StreamAdapter
 from sentry_streams.modules import get_module
-from sentry_streams.pipeline import Step
+from sentry_streams.pipeline import Map, Step
 
 
 class FlinkAdapter(StreamAdapter):
@@ -65,20 +65,21 @@ class FlinkAdapter(StreamAdapter):
 
         return stream.sink_to(sink)
 
-    def map(self, step: Step, stream: Any) -> Any:
+    def map(self, step: Map, stream: Any) -> Any:
+        if isinstance(step.function, str):
+            fn_path = step.function
+            mod, cls, fn = fn_path.rsplit(".", 2)
 
-        assert hasattr(step, "function")
-        fn_path = step.function
-        mod, cls, fn = fn_path.rsplit(".", 2)
+            try:
+                module = get_module(mod)
 
-        try:
-            module = get_module(mod)
+            except ImportError:
+                raise
 
-        except ImportError:
-            raise
-
-        imported_cls = getattr(module, cls)
-        imported_fn = getattr(imported_cls, fn)
+            imported_cls = getattr(module, cls)
+            imported_fn = getattr(imported_cls, fn)
+        else:
+            imported_fn = step.function
 
         # TODO: Ensure output type is configurable like the schema above
         return stream.map(func=lambda msg: imported_fn(msg), output_type=Types.STRING())

--- a/py/sentry_streams/pipeline.py
+++ b/py/sentry_streams/pipeline.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
-from typing import MutableMapping
+from typing import Any, Callable, MutableMapping, Union
 
 
 class StepType(Enum):
@@ -104,15 +104,23 @@ class KafkaSink(Sink):
     step_type: StepType = StepType.SINK
 
 
+# TODO: Define proper typing for messages
+MapFunction = Callable[[Any], Any]
+
+
 @dataclass
 class Map(WithInput):
     """
-    A simple 1:1 Map, taking a single input to single output
+    A simple 1:1 Map, taking a single input to single output.
     """
 
-    # TODO: Support a reference to a function (Callable)
-    # instead of a raw string
     # TODO: Allow product to both enable and access
     # configuration (e.g. a DB that is used as part of Map)
-    function: str
+
+    # We support both referencing map function via a direct reference
+    # to the symbol and through a string.
+    # The direct reference to the symbol allows for strict type checking
+    # The string is likely to be used in cross code base pipelines where
+    # the symbol is just not present in the current code base.
+    function: Union[MapFunction, str]
     step_type: StepType = StepType.MAP

--- a/py/tests/test_pipeline.py
+++ b/py/tests/test_pipeline.py
@@ -9,6 +9,7 @@ from sentry_streams.adapters.stream_adapter import RuntimeTranslator, StreamAdap
 from sentry_streams.flink.flink_adapter import FlinkAdapter
 from sentry_streams.pipeline import KafkaSink, KafkaSource, Map, Pipeline
 from sentry_streams.runner import iterate_edges
+from sentry_streams.sample_function import EventsPipelineMapFunction
 
 
 @pytest.fixture(autouse=True)
@@ -102,7 +103,7 @@ def basic_map() -> tuple[Pipeline, MutableMapping[str, list[dict[str, Any]]]]:
         name="mymap",
         ctx=pipeline,
         inputs=[source],
-        function="sentry_streams.sample_function.EventsPipelineMapFunction.simple_map",
+        function=EventsPipelineMapFunction.simple_map,
     )
 
     _ = KafkaSink(


### PR DESCRIPTION
The Map primitive only allows the user to provide the function to
use as a mapper via a fully qualified module name as a string.

While this is convenient and inevitable for pipeline that spans 
different code bases, it is not ergonomic for pipelines where the 
application code and the pipeline definition are in the same
code base.
Here by providing the Map function as a Callable allows for type
checking.


