### PR TITLE
Add the autoamtion to release sentry-streams

### DIFF
--- a/.github/workflows/build-streams.yaml
+++ b/.github/workflows/build-streams.yaml
@@ -1,0 +1,31 @@
+name: build sentry_streams
+
+on:
+  push:
+    branches:
+      - main
+      - release-sentry-streams/**
+
+jobs:
+  dist:
+    name: Create wheel and source distribution for sentry-streams
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@v3
+        - uses: actions/setup-python@v2
+          with:
+            python-version: 3.11
+
+        - name: Make environment
+          run: |
+            make install-dev
+
+        - name: "Prepare artifacts"
+          run: |
+            make build-streams
+
+        - uses: actions/upload-artifact@v3.1.1
+          with:
+                name: ${{ github.sha }}
+                path: sentry_streams/dist/*

--- a/.github/workflows/release-streams.yaml
+++ b/.github/workflows/release-streams.yaml
@@ -1,0 +1,37 @@
+name: Release sentry_streams
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: true
+      force:
+        description: Force a release even when there are release-blockers (optional)
+        required: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: "Release a new version"
+    steps:
+      - name: Get auth token
+        id: token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        with:
+          app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ steps.token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
+        env:
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+        with:
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}
+          path: sentry_streams

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,9 @@ typecheck:
 	./sentry_streams/.venv/bin/mypy --config-file sentry_streams/mypy.ini --strict sentry_streams/sentry_streams/
 	./sentry_flink/.venv/bin/mypy --config-file sentry_flink/mypy.ini --strict sentry_flink/sentry_flink/
 .PHONY: typecheck
+
+build-streams:
+	uv pip install wheel
+	uv pip install build
+	cd sentry_streams && .venv/bin/python -m build --wheel
+.PHONY: build-streams

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eux
+
+OLD_VERSION="${1}"
+NEW_VERSION="${2}"
+
+echo "Current version: $OLD_VERSION"
+echo "Bumping version: $NEW_VERSION"
+
+function replace() {
+    ! grep "$2" $3
+    perl -i -pe "s/$1/$2/g" $3
+    grep "$2" $3  # verify that replacement was successful
+}
+
+replace "version = \"[0-9.]+\""  "version = \"$NEW_VERSION\"" pyproject.toml

--- a/sentry_streams/.craft.yml
+++ b/sentry_streams/.craft.yml
@@ -1,0 +1,12 @@
+---
+minVersion: 0.34.1
+github:
+  owner: getsentry
+  repo: streams
+changelogPolicy: auto
+preReleaseCommand: bash ../sbin/bump-version.sh
+releaseBranchPrefix: release-sentry-streams
+targets:
+  - name: pypi
+  - name: sentry-pypi
+    internalPypiRepo: getsentry/pypi


### PR DESCRIPTION
Follows https://develop.sentry.dev/sdk/processes/releases/#optional-using-multiple-craft-configs-in-a-repo 
to make the repo able to release sentry-streams in the internal and external pypi.

This only releases sentry-streams so we can start importing it in other
code bases and build streaming applications without Flink in the way.
