### PR TITLE
fix: post-split javaless flink

### DIFF
--- a/platforms/flink/Dockerfile
+++ b/platforms/flink/Dockerfile
@@ -50,6 +50,6 @@ FROM build_base
 RUN python3.11 -m pip install yq
 ARG PY_PROJECT=sentry_flink/pyproject.toml
 COPY ${PY_PROJECT} ./
-RUN tomlq -r '.project.dependencies[] | select(.path | not)' pyproject.toml | jq -r '.' > ./requirements.txt
+RUN tomlq -r '.project.dependencies' pyproject.toml | jq -r '.[]' > ./requirements.txt
 RUN cat ./requirements.txt
 RUN python3.11 -m pip install -r ./requirements.txt

--- a/platforms/flink/README.md
+++ b/platforms/flink/README.md
@@ -37,7 +37,7 @@ kafka
 
 ```
 python \
-     sentry_streams/flink_runtime/flink_deploy.py \
+     sentry_flink/flink_runtime/flink_deploy.py \
      -n "My Flink App" \
      sentry_streams/example_config.py
 ```

--- a/platforms/flink/docker-compose.yml
+++ b/platforms/flink/docker-compose.yml
@@ -53,8 +53,11 @@ services:
     volumes:
       - flink_data:/tmp/
       - type: bind
-        source: ../../py/sentry_streams
+        source: ../../sentry_streams/sentry_streams
         target: /apps/sentry_streams
+      - type: bind
+        source: ../../sentry_flink/sentry_flink
+        target: /apps/sentry_flink
     ports:
       - "8081:8081"
     environment:
@@ -71,7 +74,7 @@ services:
     volumes:
       - flink_data:/tmp/
       - type: bind
-        source: ../../py/sentry_streams
+        source: ../../sentry_streams/sentry_streams
         target: /apps/sentry_streams
     environment:
       FLINK_PROPERTIES: *flink-config

--- a/sentry_flink/sentry_flink/flink_runtime/flink_deploy.py
+++ b/sentry_flink/sentry_flink/flink_runtime/flink_deploy.py
@@ -23,6 +23,12 @@ def main() -> int:
         help="The name of the Flink Job",
     )
     parser.add_argument(
+        "--adapter",
+        type=str,
+        default="sentry_flink.flink.flink_adapter.FlinkAdapter",
+        help="The name of the adapter to use",
+    )
+    parser.add_argument(
         "--jobmanager-address",
         "-a",
         type=str,
@@ -65,6 +71,8 @@ def main() -> int:
             "--name",
             args.name,
             f"/apps/{args.application}",
+            "--adapter",
+            args.adapter,
         ]
     )
 


### PR DESCRIPTION
#31 broke the docker-based flink setup because paths in the  dockerfile were hardcoded, this fixes it