### PR TITLE
ref: split user_functions part 1

### DIFF
--- a/sentry_streams/sentry_streams/example_config.py
+++ b/sentry_streams/sentry_streams/example_config.py
@@ -5,10 +5,8 @@ from sentry_streams.pipeline import (
     Map,
     Pipeline,
 )
-from sentry_streams.user_functions.sample_filter import (
-    EventsPipelineFilterFunctions,
-    EventsPipelineMapFunctions,
-)
+from sentry_streams.user_functions.sample_filter import EventsPipelineFilterFunctions
+from sentry_streams.user_functions.sample_map import EventsPipelineMapFunctions
 
 # pipeline: special name
 pipeline = Pipeline()

--- a/sentry_streams/sentry_streams/user_functions/sample_map.py
+++ b/sentry_streams/sentry_streams/user_functions/sample_map.py
@@ -1,0 +1,15 @@
+import json
+
+
+class EventsPipelineMapFunctions:
+    """
+    Sample user-defined functions to
+    plug into pipeline
+    """
+
+    @staticmethod
+    def simple_map(value: str) -> str:
+        d = json.loads(value)
+        res: str = d.get("name", "no name")
+
+        return "hello " + res


### PR DESCRIPTION
Part 1 of 2 PRs

This copies the `EventsPipelineMapFunctions` from `sample_filter.py` to a new `sample_map.py`.

The old `EventsPipelineMapFunctions` hasn't been deleted and the import paths in `sentry_flink/tests/` haven't been updated because this change will need to be deployed first. Those will be done in part 2.