### PR TITLE
ref: split user_functions part 2

### DIFF
--- a/sentry_flink/tests/test_pipeline.py
+++ b/sentry_flink/tests/test_pipeline.py
@@ -6,10 +6,8 @@ from pyflink.datastream import StreamExecutionEnvironment
 from sentry_streams.adapters.stream_adapter import RuntimeTranslator
 from sentry_streams.pipeline import Filter, KafkaSink, KafkaSource, Map, Pipeline
 from sentry_streams.runner import iterate_edges
-from sentry_streams.user_functions.sample_filter import (
-    EventsPipelineFilterFunctions,
-    EventsPipelineMapFunctions,
-)
+from sentry_streams.user_functions.sample_filter import EventsPipelineFilterFunctions
+from sentry_streams.user_functions.sample_map import EventsPipelineMapFunctions
 
 from sentry_flink.flink.flink_adapter import FlinkAdapter
 
@@ -18,7 +16,6 @@ from sentry_flink.flink.flink_adapter import FlinkAdapter
 def setup_basic_flink_env() -> (
     Generator[tuple[StreamExecutionEnvironment, RuntimeTranslator], None, None]
 ):
-
     # TODO: read from yaml file
     environment_config = {
         "topics": {

--- a/sentry_streams/sentry_streams/user_functions/sample_filter.py
+++ b/sentry_streams/sentry_streams/user_functions/sample_filter.py
@@ -14,17 +14,3 @@ class EventsPipelineFilterFunctions:
         Filter function with wrong return type, used in tests
         """
         pass
-
-
-class EventsPipelineMapFunctions:
-    """
-    Sample user-defined functions to
-    plug into pipeline
-    """
-
-    @staticmethod
-    def simple_map(value: str) -> str:
-        d = json.loads(value)
-        res: str = d.get("name", "no name")
-
-        return "hello " + res


### PR DESCRIPTION
Part 2 of 2, part 1 is #53 

After #53 has been deployed, this cleanup PR can be merged and both `senrty_streams` & `sentry_flink` can be deployed.