### PR TITLE
ref(sentry_streams): add function to TransformStep class

### DIFF
--- a/sentry_streams/sentry_streams/pipeline/pipeline.py
+++ b/sentry_streams/sentry_streams/pipeline/pipeline.py
@@ -14,6 +14,7 @@ from typing import (
     cast,
 )
 
+from sentry_streams.modules import get_module
 from sentry_streams.pipeline.function_template import (
     Accumulator,
     AggregationBackend,
@@ -22,8 +23,6 @@ from sentry_streams.pipeline.function_template import (
     OutputType,
 )
 from sentry_streams.pipeline.window import MeasurementUnit, Window
-
-from ..modules import get_module
 
 
 class StepType(Enum):

--- a/sentry_streams/sentry_streams/pipeline/pipeline.py
+++ b/sentry_streams/sentry_streams/pipeline/pipeline.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Generic, MutableMapping, Optional, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    MutableMapping,
+    Optional,
+    TypeVar,
+    Union,
+    cast,
+)
 
 from sentry_streams.pipeline.function_template import (
     Accumulator,
@@ -13,6 +22,8 @@ from sentry_streams.pipeline.function_template import (
     OutputType,
 )
 from sentry_streams.pipeline.window import MeasurementUnit, Window
+
+from ..modules import get_module
 
 
 class StepType(Enum):
@@ -123,10 +134,35 @@ class TransformStep(WithInput, Generic[T]):
     """
     A generic step representing a step performing a transform operation
     on input data.
+    function: supports relative path using dot notation, or a Callable
+    TODO: add support for absolute path
     """
 
     function: Union[Callable[..., T], str]
     step_type: StepType
+
+    @property
+    def resolved_function(self) -> Callable[..., T]:
+        """
+        Returns a callable of the transform function defined, or referenced in the
+        this class
+        """
+        if isinstance(self.function, str):
+            fn_path = self.function
+            mod, cls, fn = fn_path.rsplit(".", 2)
+
+            try:
+                module = get_module(mod)
+
+            except ImportError:
+                raise
+
+            imported_cls = getattr(module, cls)
+            imported_func = cast(Callable[..., T], getattr(imported_cls, fn))
+            function_callable = imported_func
+        else:
+            function_callable = self.function
+        return function_callable
 
 
 @dataclass

--- a/sentry_streams/sentry_streams/pipeline/pipeline.py
+++ b/sentry_streams/sentry_streams/pipeline/pipeline.py
@@ -133,8 +133,7 @@ class TransformStep(WithInput, Generic[T]):
     """
     A generic step representing a step performing a transform operation
     on input data.
-    function: supports relative path using dot notation, or a Callable
-    TODO: add support for absolute path
+    function: supports reference to a function using dot notation, or a Callable
     """
 
     function: Union[Callable[..., T], str]

--- a/sentry_streams/sentry_streams/pipeline/pipeline.py
+++ b/sentry_streams/sentry_streams/pipeline/pipeline.py
@@ -145,21 +145,17 @@ class TransformStep(WithInput, Generic[T]):
         Returns a callable of the transform function defined, or referenced in the
         this class
         """
-        if isinstance(self.function, str):
-            fn_path = self.function
-            mod, cls, fn = fn_path.rsplit(".", 2)
+        if callable(self.function):
+            return self.function
 
-            try:
-                module = get_module(mod)
+        fn_path = self.function
+        mod, cls, fn = fn_path.rsplit(".", 2)
 
-            except ImportError:
-                raise
+        module = get_module(mod)
 
-            imported_cls = getattr(module, cls)
-            imported_func = cast(Callable[..., T], getattr(imported_cls, fn))
-            function_callable = imported_func
-        else:
-            function_callable = self.function
+        imported_cls = getattr(module, cls)
+        imported_func = cast(Callable[..., T], getattr(imported_cls, fn))
+        function_callable = imported_func
         return function_callable
 
 

--- a/sentry_streams/tests/test_pipeline.py
+++ b/sentry_streams/tests/test_pipeline.py
@@ -110,15 +110,6 @@ class ExampleClass:
         return "nothing"
 
 
-# def _get_current_module_path() -> str:
-#     current_file_absolute = Path(__file__).resolve()
-
-#     script_dir = Path.cwd()
-#     path_relative = current_file_absolute.relative_to(script_dir)
-#     path_relative_str = str(path_relative).replace("/", ".").rstrip(".py")
-#     return path_relative_str
-
-
 @pytest.mark.parametrize(
     "function, expected",
     [

--- a/sentry_streams/tests/test_pipeline.py
+++ b/sentry_streams/tests/test_pipeline.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Any, Callable, Union
 
 import pytest
@@ -111,25 +110,25 @@ class ExampleClass:
         return "nothing"
 
 
-def _get_current_module_path() -> str:
-    current_file_absolute = Path(__file__).resolve()
+# def _get_current_module_path() -> str:
+#     current_file_absolute = Path(__file__).resolve()
 
-    script_dir = Path.cwd()
-    path_relative = current_file_absolute.relative_to(script_dir)
-    path_relative_str = str(path_relative).replace("/", ".").rstrip(".py")
-    return path_relative_str
+#     script_dir = Path.cwd()
+#     path_relative = current_file_absolute.relative_to(script_dir)
+#     path_relative_str = str(path_relative).replace("/", ".").rstrip(".py")
+#     return path_relative_str
 
 
 @pytest.mark.parametrize(
     "function, expected",
     [
         pytest.param(
-            f"{_get_current_module_path()}.ExampleClass.example_func",
+            "tests.test_pipeline.ExampleClass.example_func",
             ExampleClass.example_func,
             id="Function is a string of an relative path, referring to a function inside a class",
         ),
         pytest.param(
-            f"{_get_current_module_path()}.simple_map",
+            "tests.test_pipeline.simple_map",
             simple_map,
             id="Function is a string of an relative path, referring to a function outside of a class",
         ),


### PR DESCRIPTION
PR 1/2 of ticket https://github.com/getsentry/streams/issues/40?issue=getsentry%7Cstreams%7C43

the function `get_function` is copy pasted from https://github.com/getsentry/streams/blob/65f71d4e46a6eff24f5e331e6e09b14ab8401877/sentry_flink/sentry_flink/flink/flink_adapter.py#L57-L78, did not edit logic

After this is merged, I will create a new release of sentry_streams, then remove the function from flink_adapter file linked above
