### PR TITLE
ref: Remove Unbatch, flesh out Reduce ABC

### DIFF
--- a/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
@@ -17,9 +17,13 @@ from sentry_streams.adapters.arroyo.consumer import (
 from sentry_streams.adapters.arroyo.routes import Route
 from sentry_streams.adapters.arroyo.steps import FilterStep, KafkaSinkStep, MapStep
 from sentry_streams.adapters.stream_adapter import PipelineConfig, StreamAdapter
+from sentry_streams.pipeline.function_template import (
+    InputType,
+    OutputType,
+)
 from sentry_streams.pipeline.pipeline import (
     Filter,
-    FlatMapStep,
+    FlatMap,
     KafkaSink,
     KafkaSource,
     Map,
@@ -27,6 +31,7 @@ from sentry_streams.pipeline.pipeline import (
     Sink,
     Source,
 )
+from sentry_streams.pipeline.window import MeasurementUnit
 
 
 class KafkaConsumerConfig(TypedDict):
@@ -176,7 +181,7 @@ class ArroyoAdapter(StreamAdapter[Route, Route]):
         self.__consumers[stream.source].add_step(MapStep(route=stream, pipeline_step=step))
         return stream
 
-    def flat_map(self, step: FlatMapStep, stream: Route) -> Route:
+    def flat_map(self, step: FlatMap, stream: Route) -> Route:
         """
         Builds a flat-map operator for the platform the adapter supports.
         """
@@ -195,7 +200,7 @@ class ArroyoAdapter(StreamAdapter[Route, Route]):
 
     def reduce(
         self,
-        step: Reduce,
+        step: Reduce[MeasurementUnit, InputType, OutputType],
         stream: Route,
     ) -> Route:
         """

--- a/sentry_streams/sentry_streams/adapters/stream_adapter.py
+++ b/sentry_streams/sentry_streams/adapters/stream_adapter.py
@@ -10,9 +10,13 @@ from typing import (
     assert_never,
 )
 
+from sentry_streams.pipeline.function_template import (
+    InputType,
+    OutputType,
+)
 from sentry_streams.pipeline.pipeline import (
     Filter,
-    FlatMapStep,
+    FlatMap,
     Map,
     Reduce,
     Sink,
@@ -20,6 +24,7 @@ from sentry_streams.pipeline.pipeline import (
     Step,
     StepType,
 )
+from sentry_streams.pipeline.window import MeasurementUnit
 
 PipelineConfig = Mapping[str, Any]
 
@@ -75,7 +80,7 @@ class StreamAdapter(ABC, Generic[Stream, StreamSink]):
         raise NotImplementedError
 
     @abstractmethod
-    def flat_map(self, step: FlatMapStep, stream: Stream) -> Stream:
+    def flat_map(self, step: FlatMap, stream: Stream) -> Stream:
         """
         Builds a flat-map operator for the platform the adapter supports.
         """
@@ -91,7 +96,7 @@ class StreamAdapter(ABC, Generic[Stream, StreamSink]):
     @abstractmethod
     def reduce(
         self,
-        step: Reduce,
+        step: Reduce[MeasurementUnit, InputType, OutputType],
         stream: Stream,
     ) -> Stream:
         """
@@ -137,7 +142,7 @@ class RuntimeTranslator(Generic[Stream, StreamSink]):
             return self.adapter.map(step, stream)
 
         elif step_type is StepType.FLAT_MAP:
-            assert isinstance(step, FlatMapStep) and stream is not None
+            assert isinstance(step, FlatMap) and stream is not None
             return self.adapter.flat_map(step, stream)
 
         elif step_type is StepType.REDUCE:

--- a/sentry_streams/sentry_streams/examples/alerts.py
+++ b/sentry_streams/sentry_streams/examples/alerts.py
@@ -1,9 +1,12 @@
 from sentry_streams.examples.events import (
     AlertsBuffer,
+    CountAlertData,
     GroupByAlertID,
+    TimeSeriesDataPoint,
     build_alert_json,
     build_event,
     materialize_alerts,
+    p95AlertData,
 )
 from sentry_streams.pipeline.pipeline import (
     Aggregate,
@@ -42,12 +45,12 @@ reduce_window = TumblingWindow(window_size=3)
 # Actually aggregates all the time series data points for each
 # alert rule registered (alert ID). Returns an aggregate value
 # for each window.
-reduce = Aggregate(
+reduce: Aggregate[int, TimeSeriesDataPoint, p95AlertData | CountAlertData] = Aggregate(
     name="myreduce",
     ctx=pipeline,
     inputs=[flat_map],
-    windowing=reduce_window,
-    aggregate_fn=AlertsBuffer,
+    window=reduce_window,
+    aggregate_func=AlertsBuffer,
     group_by_key=GroupByAlertID(),
 )
 

--- a/sentry_streams/sentry_streams/examples/batching.py
+++ b/sentry_streams/sentry_streams/examples/batching.py
@@ -1,13 +1,14 @@
 import json
 
+from sentry_streams.pipeline.batch import unbatch
 from sentry_streams.pipeline.function_template import InputType
 from sentry_streams.pipeline.pipeline import (
     Batch,
+    FlatMap,
     KafkaSink,
     KafkaSource,
     Map,
     Pipeline,
-    Unbatch,
 )
 
 
@@ -36,9 +37,9 @@ source = KafkaSource(
 # User simply provides the batch size
 reduce: Batch[int, str] = Batch(name="mybatch", ctx=pipeline, inputs=[source], batch_size=5)
 
-unbatch: Unbatch[str] = Unbatch(name="myunbatch", ctx=pipeline, inputs=[reduce])
+flat_map = FlatMap(name="myunbatch", ctx=pipeline, inputs=[reduce], function=unbatch)
 
-map = Map(name="mymap", ctx=pipeline, inputs=[unbatch], function=build_message_str)
+map = Map(name="mymap", ctx=pipeline, inputs=[flat_map], function=build_message_str)
 
 # flush the batches to the Sink
 sink = KafkaSink(

--- a/sentry_streams/sentry_streams/examples/billing.py
+++ b/sentry_streams/sentry_streams/examples/billing.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 
 from sentry_streams.examples.billing_buffer import OutcomesBuffer
 from sentry_streams.pipeline.function_template import KVAggregationBackend
@@ -40,11 +41,11 @@ map = Map(
 # Windows are assigned 3 elements.
 reduce_window = TumblingWindow(window_size=3)
 
-reduce = Aggregate(
+reduce: Aggregate[int, Outcome, dict[Any, Any]] = Aggregate(
     name="myreduce",
     ctx=pipeline,
     inputs=[map],
-    windowing=reduce_window,
-    aggregate_fn=OutcomesBuffer,
+    window=reduce_window,
+    aggregate_func=OutcomesBuffer,
     aggregate_backend=KVAggregationBackend(),  # NOTE: Provided by the platform
 )

--- a/sentry_streams/sentry_streams/examples/spans_buffer.py
+++ b/sentry_streams/sentry_streams/examples/spans_buffer.py
@@ -39,8 +39,8 @@ reduce = Aggregate(
     name="myreduce",
     ctx=pipeline,
     inputs=[map],
-    windowing=reduce_window,
-    aggregate_fn=SpansBuffer,
+    window=reduce_window,
+    aggregate_func=SpansBuffer,
 )
 
 map_str = Map(

--- a/sentry_streams/sentry_streams/examples/word_counter.py
+++ b/sentry_streams/sentry_streams/examples/word_counter.py
@@ -42,12 +42,12 @@ map = Map(
 # TODO: Get the parameters for window in pipeline configuration.
 reduce_window = TumblingWindow(window_size=3)
 
-reduce = Aggregate(
+reduce: Aggregate[int, tuple[str, int], str] = Aggregate(
     name="myreduce",
     ctx=pipeline,
     inputs=[map],
-    windowing=reduce_window,
-    aggregate_fn=WordCounter,
+    window=reduce_window,
+    aggregate_func=WordCounter,
     group_by_key=GroupByWord(),
 )
 

--- a/sentry_streams/sentry_streams/pipeline/pipeline.py
+++ b/sentry_streams/sentry_streams/pipeline/pipeline.py
@@ -9,6 +9,7 @@ from typing import (
     Callable,
     Generic,
     MutableMapping,
+    MutableSequence,
     Optional,
     TypeVar,
     Union,
@@ -249,7 +250,7 @@ BatchInput = TypeVar("BatchInput")
 
 
 @dataclass
-class Batch(Reduce[MeasurementUnit, InputType, OutputType]):
+class Batch(Reduce[MeasurementUnit, InputType, MutableSequence[InputType]]):
     """
     A step to Batch up the results of the prior step.
 

--- a/sentry_streams/sentry_streams/pipeline/pipeline.py
+++ b/sentry_streams/sentry_streams/pipeline/pipeline.py
@@ -16,7 +16,7 @@ from typing import (
 )
 
 from sentry_streams.modules import get_module
-from sentry_streams.pipeline.batch import BatchBuilder, unbatch
+from sentry_streams.pipeline.batch import BatchBuilder
 from sentry_streams.pipeline.function_template import (
     Accumulator,
     AggregationBackend,
@@ -252,30 +252,10 @@ class Batch(Reduce, Generic[MeasurementUnit, InputType]):
 
 
 @dataclass
-class FlatMapStep(WithInput):
+class FlatMap(TransformStep[Any]):
     """
     A generic step for mapping and flattening (and therefore alerting the shape of) inputs to
     get outputs. Takes a single input to 0...N outputs.
     """
 
     step_type: StepType = StepType.FLAT_MAP
-
-
-@dataclass
-class FlatMap(FlatMapStep, TransformStep[Any]):
-    """
-    A FlatMap with a user-defined function.
-    """
-
-
-@dataclass
-class Unbatch(FlatMapStep, TransformFunction[T]):
-    """
-    A step to flatten a batch representation to output its individual elements.
-    """
-
-    @property
-    def resolved_function(
-        self,
-    ) -> Callable[..., T]:
-        return cast(Callable[..., T], unbatch)


### PR DESCRIPTION
Some refactoring to Batch and FlatMap primitives. 

Removed the Unbatch primitive, as I don't think it should be a primitive that is independent from FlatMap. There is not much that an Unbatch primitive abstracts away. In fact, even if we exposed an Unbatch, a user would still need to know the format of data flowing through the pipeline: an Unbatch cannot be plugged in "anywhere" in a pipeline. This same argument doesn't apply to Batch, because it _does_ actually abstract away some details and _can_ technically be used as an independent building block anywhere in the pipeline. 

I think this makes the usability of the API better, and actually reduces the cognitive overhead of using it. As a side effect, the typing is also clearer.