### PR TITLE
Adapte the runner to run the Arroyo adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,37 @@
 
 The Sentry Streaming Platform
 
-# Run pyFlink application locally.
+This repo contains two libraries: `sentry_streams` and `sentry_flink`.
 
-PyFlink application can run with an embedded flink without having to run
-the Flink Server in a stand alone way. Just run the application in the
-Python interpreter.
+The first contain all the streaming api and an Arroyo based adapter to run
+the streaming applications on top of Arroyo.
 
-Run `direnv allow`.
+The second contains the Flink adapter to run streaming applications on
+Apache Flink. This part is in a separate library because, until we will not
+be able to make it run on python 3.13 and produce wheels for python 3.13,
+it will require Java to run even in the dev environment.
 
-See [here](./platforms/flink/README.md) for the steps to run Flink in a container.
+## Quickstart
 
-Run
+We are going to run a streaming application on top of Arroyo.
+
+1. Run `make install-dev`
+
+2. Go to the sentry_streams directory
+
+3. Activate the virtual environment: `source .venv/bin/activate`
+
+4. Run one of the examples
 
 ```
-docker exec -it kafka \
-    kafka-topics \
-    --bootstrap-server localhost:29092 \
-    --topic events \
-    --create
+python sentry_streams/runner.py \
+    -n test \
+    -b localhost:9092 \
+    -a arroyo \
+    sentry_streams/examples/transfomer.py
 ```
 
-Run `echo '{"test": "hello world"}' | kcat -P -b 127.0.0.1:9092 -t events` to send some events and see them printed.
+This will start an Arroyo consumer that runs the streaming application defined
+in `sentry_streams/examples/transfomer.py`.
 
-If you have Java installed you can skip the container and just run the
-application python file directly. That will start Flink.
+there is a number of examples in the `sentry_streams/examples` directory.

--- a/sentry_flink/README.md
+++ b/sentry_flink/README.md
@@ -1,0 +1,24 @@
+# Run pyFlink application locally.
+
+PyFlink application can run with an embedded flink without having to run
+the Flink Server in a stand alone way. Just run the application in the
+Python interpreter.
+
+Run `direnv allow`.
+
+See [here](./platforms/flink/README.md) for the steps to run Flink in a container.
+
+Run
+
+```
+docker exec -it kafka \
+    kafka-topics \
+    --bootstrap-server localhost:29092 \
+    --topic events \
+    --create
+```
+
+Run `echo '{"test": "hello world"}' | kcat -P -b 127.0.0.1:9092 -t events` to send some events and see them printed.
+
+If you have Java installed you can skip the container and just run the
+application python file directly. That will start Flink.

--- a/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Mapping, MutableMapping, TypedDict
+from typing import Any, Mapping, MutableMapping, Self, TypedDict
 
 from arroyo.backends.kafka.configuration import (
     build_kafka_configuration,
@@ -113,7 +113,7 @@ class ArroyoAdapter(StreamAdapter[Route, Route]):
         self.__consumers: MutableMapping[str, ArroyoConsumer] = {}
 
     @classmethod
-    def build(cls, config: PipelineConfig) -> ArroyoAdapter:
+    def build(cls, config: PipelineConfig) -> Self:
         return cls(
             config["sources_config"],
             config["sinks_config"],

--- a/sentry_streams/sentry_streams/adapters/loader.py
+++ b/sentry_streams/sentry_streams/adapters/loader.py
@@ -32,6 +32,17 @@ def load_adapter(adapter_type: str, config: PipelineConfig) -> StreamAdapter[Str
         from sentry_streams.dummy.dummy_adapter import DummyAdapter
 
         return DummyAdapter.build(config)
+    if adapter_type == "arroyo":
+        from sentry_streams.adapters.arroyo import ArroyoAdapter
+
+        # TODO: The runner deserves a refactoring. The way it is designed
+        # it is impossible to create adapters that materialize the type of
+        # the `Stream` generic and be able to return a generic here. In order
+        # to make it possible the generic would have to be covariant. But we
+        # use the generic attribute both as a parameter and return value.
+        # So we need to move responsibilities from iterate_edges to the adapter
+        # to have a sane type structure.
+        return cast(StreamAdapter[Stream, Sink], ArroyoAdapter.build(config))
     else:
         mod, cls = adapter_type.rsplit(".", 1)
 

--- a/sentry_streams/sentry_streams/adapters/stream_adapter.py
+++ b/sentry_streams/sentry_streams/adapters/stream_adapter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import (
     Any,

--- a/sentry_streams/sentry_streams/adapters/stream_adapter.py
+++ b/sentry_streams/sentry_streams/adapters/stream_adapter.py
@@ -113,6 +113,13 @@ class StreamAdapter(ABC, Generic[Stream, StreamSink]):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def shutdown(self) -> None:
+        """
+        Cleanly shutdown the application.
+        """
+        raise NotImplementedError
+
 
 class RuntimeTranslator(Generic[Stream, StreamSink]):
     """

--- a/sentry_streams/sentry_streams/dummy/dummy_adapter.py
+++ b/sentry_streams/sentry_streams/dummy/dummy_adapter.py
@@ -33,3 +33,6 @@ class DummyAdapter(StreamAdapter[DummyInput, DummyOutput]):
 
     def run(self) -> None:
         pass
+
+    def shutdown(self) -> None:
+        pass

--- a/sentry_streams/sentry_streams/examples/transfomer.py
+++ b/sentry_streams/sentry_streams/examples/transfomer.py
@@ -1,0 +1,50 @@
+from json import JSONDecodeError, dumps, loads
+from typing import Any, Mapping, cast
+
+from sentry_streams.pipeline.pipeline import (
+    Filter,
+    KafkaSink,
+    KafkaSource,
+    Map,
+    Pipeline,
+)
+
+# The simplest possible pipeline.
+# - reads from Kafka
+# - parses the event
+# - filters the event based on an attribute
+# - serializes the event into json
+# - produces the event on Kafka
+
+
+def parse(msg: str) -> Mapping[str, Any]:
+    try:
+        parsed = loads(msg)
+    except JSONDecodeError:
+        return {"type": "invalid"}
+
+    return cast(Mapping[str, Any], parsed)
+
+
+pipeline = Pipeline()
+
+source = KafkaSource(
+    name="myinput",
+    ctx=pipeline,
+    logical_topic="events",
+)
+
+parser = Map(name="parser", ctx=pipeline, inputs=[source], function=parse)
+
+filter = Filter(
+    name="myfilter", ctx=pipeline, inputs=[parser], function=lambda msg: msg["type"] == "event"
+)
+
+jsonify = Map(name="serializer", ctx=pipeline, inputs=[filter], function=lambda msg: dumps(msg))
+
+sink = KafkaSink(
+    name="kafkasink",
+    ctx=pipeline,
+    inputs=[jsonify],
+    logical_topic="transformed-events",
+)

--- a/sentry_streams/sentry_streams/runner.py
+++ b/sentry_streams/sentry_streams/runner.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import signal
 from typing import Any, cast
 
 from sentry_streams.adapters.loader import load_adapter
@@ -135,6 +136,13 @@ def main() -> None:
     translator = RuntimeTranslator(runtime)
 
     iterate_edges(pipeline, translator)
+
+    def signal_handler(sig: int, frame: Any) -> None:
+        logger.info("Signal received, terminating the runner...")
+        runtime.shutdown()
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
 
     runtime.run()
 

--- a/sentry_streams/tests/adapters/arroyo/test_adapter.py
+++ b/sentry_streams/tests/adapters/arroyo/test_adapter.py
@@ -62,6 +62,7 @@ def test_adapter(broker: LocalBroker[KafkaPayload], pipeline: Pipeline) -> None:
     )
     iterate_edges(pipeline, RuntimeTranslator(adapter))
 
+    adapter.create_processors()
     processor = adapter.get_processor("myinput")
 
     broker.produce(


### PR DESCRIPTION
The arroyo adapter was not wired onto the runner so we could not 
actually run Arroyo consumers. This wires it up together.

Specifically:
- the loader can instantiate an Arroyo adapter now. 
  There are types to fix but that requires a larger change.
- Initialized the logger with a reasonable format and replaced
  some print with log statements
- Added a signal handler on the runner 
- Fixed the readme by adding a quickstart section

