### PR TITLE
Make streams less Kafkaesque

### DIFF
--- a/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
@@ -86,7 +86,7 @@ class StreamSources:
                 )
             )
 
-        self.__source_topics[source_name] = Topic(step.stream)
+        self.__source_topics[source_name] = Topic(step.stream_name)
 
     def get_topic(self, source: str) -> Topic:
         return self.__source_topics[source]
@@ -167,7 +167,7 @@ class ArroyoAdapter(StreamAdapter[Route, Route]):
         ), f"Stream starting at source {stream.source} not found when adding a producer"
 
         self.__consumers[stream.source].add_step(
-            StreamSinkStep(route=stream, producer=producer, topic_name=step.stream)
+            StreamSinkStep(route=stream, producer=producer, topic_name=step.stream_name)
         )
 
         return stream

--- a/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
@@ -72,7 +72,7 @@ class StreamSources:
         """
         # TODO: Provide a better way to get the logical stream name from
         # the Sink step. We should not have to assert it is a Kafka sink
-        assert isinstance(step, StreamSource), "Only Kafka Sources are supported"
+        assert isinstance(step, StreamSource), "Only Stream Sources are supported"
         source_name = step.name
         if source_name not in self.__sources:
             config = self.__sources_config.get(source_name)

--- a/sentry_streams/sentry_streams/adapters/arroyo/steps.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/steps.py
@@ -126,9 +126,9 @@ class FilterStep(ArroyoStep):
 
 
 @dataclass
-class KafkaSinkStep(ArroyoStep):
+class StreamSinkStep(ArroyoStep):
     """
-    Represents an Arroyo producer. This is mapped from a KafkaSink in the pipeline.
+    Represents an Arroyo producer. This is mapped from a StreamSink in the pipeline.
 
     It filters out messages for the route not specified on this step and unpacks
     the routed message into the original Arroyo payload.

--- a/sentry_streams/sentry_streams/examples/alerts.py
+++ b/sentry_streams/sentry_streams/examples/alerts.py
@@ -11,19 +11,19 @@ from sentry_streams.examples.events import (
 from sentry_streams.pipeline.pipeline import (
     Aggregate,
     FlatMap,
-    KafkaSink,
-    KafkaSource,
     Map,
     Pipeline,
+    StreamSink,
+    StreamSource,
 )
 from sentry_streams.pipeline.window import TumblingWindow
 
 pipeline = Pipeline()
 
-source = KafkaSource(
+source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    logical_topic="logical-events",
+    stream="logical-events",
 )
 
 map = Map(
@@ -61,9 +61,9 @@ map_str = Map(
     function=build_alert_json,
 )
 
-sink = KafkaSink(
+sink = StreamSink(
     name="kafkasink",
     ctx=pipeline,
     inputs=[map_str],
-    logical_topic="transformed-events",
+    stream="transformed-events",
 )

--- a/sentry_streams/sentry_streams/examples/alerts.py
+++ b/sentry_streams/sentry_streams/examples/alerts.py
@@ -23,7 +23,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    stream="logical-events",
+    stream_name="logical-events",
 )
 
 map = Map(
@@ -65,5 +65,5 @@ sink = StreamSink(
     name="kafkasink",
     ctx=pipeline,
     inputs=[map_str],
-    stream="transformed-events",
+    stream_name="transformed-events",
 )

--- a/sentry_streams/sentry_streams/examples/batching.py
+++ b/sentry_streams/sentry_streams/examples/batching.py
@@ -5,10 +5,10 @@ from sentry_streams.pipeline.function_template import InputType
 from sentry_streams.pipeline.pipeline import (
     Batch,
     FlatMap,
-    KafkaSink,
-    KafkaSource,
     Map,
     Pipeline,
+    StreamSink,
+    StreamSource,
 )
 
 
@@ -28,10 +28,10 @@ def build_message_str(message: str) -> str:
 
 pipeline = Pipeline()
 
-source = KafkaSource(
+source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    logical_topic="logical-events",
+    stream="logical-events",
 )
 
 # User simply provides the batch size
@@ -42,9 +42,9 @@ flat_map = FlatMap(name="myunbatch", ctx=pipeline, inputs=[reduce], function=unb
 map = Map(name="mymap", ctx=pipeline, inputs=[flat_map], function=build_message_str)
 
 # flush the batches to the Sink
-sink = KafkaSink(
+sink = StreamSink(
     name="kafkasink",
     ctx=pipeline,
     inputs=[map],
-    logical_topic="transformed-events",
+    stream="transformed-events",
 )

--- a/sentry_streams/sentry_streams/examples/batching.py
+++ b/sentry_streams/sentry_streams/examples/batching.py
@@ -31,7 +31,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    stream="logical-events",
+    stream_name="logical-events",
 )
 
 # User simply provides the batch size
@@ -46,5 +46,5 @@ sink = StreamSink(
     name="kafkasink",
     ctx=pipeline,
     inputs=[map],
-    stream="transformed-events",
+    stream_name="transformed-events",
 )

--- a/sentry_streams/sentry_streams/examples/billing.py
+++ b/sentry_streams/sentry_streams/examples/billing.py
@@ -27,7 +27,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    stream="logical-events",
+    stream_name="logical-events",
 )
 
 map = Map(

--- a/sentry_streams/sentry_streams/examples/billing.py
+++ b/sentry_streams/sentry_streams/examples/billing.py
@@ -5,9 +5,9 @@ from sentry_streams.examples.billing_buffer import OutcomesBuffer
 from sentry_streams.pipeline.function_template import KVAggregationBackend
 from sentry_streams.pipeline.pipeline import (
     Aggregate,
-    KafkaSource,
     Map,
     Pipeline,
+    StreamSource,
 )
 from sentry_streams.pipeline.window import TumblingWindow
 
@@ -24,10 +24,10 @@ def build_outcome(value: str) -> Outcome:
 # pipeline: special name
 pipeline = Pipeline()
 
-source = KafkaSource(
+source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    logical_topic="logical-events",
+    stream="logical-events",
 )
 
 map = Map(

--- a/sentry_streams/sentry_streams/examples/blq.py
+++ b/sentry_streams/sentry_streams/examples/blq.py
@@ -19,7 +19,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="ingest",
     ctx=pipeline,
-    stream="logical-events",
+    stream_name="logical-events",
 )
 
 unpack_msg = Map(
@@ -58,19 +58,19 @@ sbc_sink = StreamSink(
     name="sbc_sinkStreamSource",
     ctx=pipeline,
     inputs=[dump_msg_recent],
-    stream="transformed-events",
+    stream_name="transformed-events",
 )
 
 clickhouse_sink = StreamSink(
     name="clickhouse_sinkStreamSource",
     ctx=pipeline,
     inputs=[dump_msg_recent],
-    stream="transformed-eventStreamSource-2",
+    stream_name="transformed-eventStreamSource-2",
 )
 
 delayed_msg_sink = StreamSink(
     name="delayed_msg_sinkStreamSource",
     ctx=pipeline,
     inputs=[dump_msg_delayed],
-    stream="transformed-eventStreamSourceStreamSource",
+    stream_name="transformed-eventStreamSourceStreamSource",
 )

--- a/sentry_streams/sentry_streams/examples/blq.py
+++ b/sentry_streams/sentry_streams/examples/blq.py
@@ -6,20 +6,20 @@ from sentry_streams.examples.blq_fn import (
 )
 from sentry_streams.pipeline.pipeline import (
     Branch,
-    KafkaSink,
-    KafkaSource,
     Map,
     Pipeline,
     Router,
+    StreamSink,
+    StreamSource,
 )
 
 # pipeline: special name
 pipeline = Pipeline()
 
-source = KafkaSource(
+source = StreamSource(
     name="ingest",
     ctx=pipeline,
-    logical_topic="logical-events",
+    stream="logical-events",
 )
 
 unpack_msg = Map(
@@ -54,23 +54,23 @@ dump_msg_delayed = Map(
     function=json_dump_message,
 )
 
-sbc_sink = KafkaSink(
-    name="sbc_sink",
+sbc_sink = StreamSink(
+    name="sbc_sinkStreamSource",
     ctx=pipeline,
     inputs=[dump_msg_recent],
-    logical_topic="transformed-events",
+    stream="transformed-events",
 )
 
-clickhouse_sink = KafkaSink(
-    name="clickhouse_sink",
+clickhouse_sink = StreamSink(
+    name="clickhouse_sinkStreamSource",
     ctx=pipeline,
     inputs=[dump_msg_recent],
-    logical_topic="transformed-events-2",
+    stream="transformed-eventStreamSource-2",
 )
 
-delayed_msg_sink = KafkaSink(
-    name="delayed_msg_sink",
+delayed_msg_sink = StreamSink(
+    name="delayed_msg_sinkStreamSource",
     ctx=pipeline,
     inputs=[dump_msg_delayed],
-    logical_topic="transformed-events-3",
+    stream="transformed-eventStreamSourceStreamSource",
 )

--- a/sentry_streams/sentry_streams/examples/broadcast.py
+++ b/sentry_streams/sentry_streams/examples/broadcast.py
@@ -11,7 +11,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    stream="logical-events",
+    stream_name="logical-events",
 )
 
 map = Map(
@@ -39,12 +39,12 @@ hello_sink = StreamSink(
     name="hello_sink",
     ctx=pipeline,
     inputs=[hello_map],
-    stream="transformed-events",
+    stream_name="transformed-events",
 )
 
 goodbye_sink = StreamSink(
     name="goodbye_sink",
     ctx=pipeline,
     inputs=[goodbye_map],
-    stream="transformed-events-2",
+    stream_name="transformed-events-2",
 )

--- a/sentry_streams/sentry_streams/examples/broadcast.py
+++ b/sentry_streams/sentry_streams/examples/broadcast.py
@@ -1,17 +1,17 @@
 from sentry_streams.examples.broadcast_fn import BroadcastFunctions
 from sentry_streams.pipeline.pipeline import (
-    KafkaSink,
-    KafkaSource,
     Map,
     Pipeline,
+    StreamSink,
+    StreamSource,
 )
 
 pipeline = Pipeline()
 
-source = KafkaSource(
+source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    logical_topic="logical-events",
+    stream="logical-events",
 )
 
 map = Map(
@@ -35,16 +35,16 @@ goodbye_map = Map(
     function=BroadcastFunctions.goodbye_map,
 )
 
-hello_sink = KafkaSink(
+hello_sink = StreamSink(
     name="hello_sink",
     ctx=pipeline,
     inputs=[hello_map],
-    logical_topic="transformed-events",
+    stream="transformed-events",
 )
 
-goodbye_sink = KafkaSink(
+goodbye_sink = StreamSink(
     name="goodbye_sink",
     ctx=pipeline,
     inputs=[goodbye_map],
-    logical_topic="transformed-events-2",
+    stream="transformed-events-2",
 )

--- a/sentry_streams/sentry_streams/examples/spans_buffer.py
+++ b/sentry_streams/sentry_streams/examples/spans_buffer.py
@@ -15,7 +15,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    stream="logical-events",
+    stream_name="logical-events",
 )
 
 map = Map(
@@ -54,5 +54,5 @@ sink = StreamSink(
     name="kafkasink",
     ctx=pipeline,
     inputs=[map_str],
-    stream="transformed-events",
+    stream_name="transformed-events",
 )

--- a/sentry_streams/sentry_streams/examples/spans_buffer.py
+++ b/sentry_streams/sentry_streams/examples/spans_buffer.py
@@ -3,19 +3,19 @@ from datetime import timedelta
 from sentry_streams.examples.spans import SpansBuffer, build_segment_json, build_span
 from sentry_streams.pipeline.pipeline import (
     Aggregate,
-    KafkaSink,
-    KafkaSource,
     Map,
     Pipeline,
+    StreamSink,
+    StreamSource,
 )
 from sentry_streams.pipeline.window import TumblingWindow
 
 pipeline = Pipeline()
 
-source = KafkaSource(
+source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    logical_topic="logical-events",
+    stream="logical-events",
 )
 
 map = Map(
@@ -50,9 +50,9 @@ map_str = Map(
     function=build_segment_json,
 )
 
-sink = KafkaSink(
+sink = StreamSink(
     name="kafkasink",
     ctx=pipeline,
     inputs=[map_str],
-    logical_topic="transformed-events",
+    stream="transformed-events",
 )

--- a/sentry_streams/sentry_streams/examples/transfomer.py
+++ b/sentry_streams/sentry_streams/examples/transfomer.py
@@ -3,10 +3,10 @@ from typing import Any, Mapping, cast
 
 from sentry_streams.pipeline.pipeline import (
     Filter,
-    KafkaSink,
-    KafkaSource,
     Map,
     Pipeline,
+    StreamSink,
+    StreamSource,
 )
 
 # The simplest possible pipeline.
@@ -28,10 +28,10 @@ def parse(msg: str) -> Mapping[str, Any]:
 
 pipeline = Pipeline()
 
-source = KafkaSource(
+source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    logical_topic="events",
+    stream="events",
 )
 
 parser = Map(name="parser", ctx=pipeline, inputs=[source], function=parse)
@@ -42,9 +42,9 @@ filter = Filter(
 
 jsonify = Map(name="serializer", ctx=pipeline, inputs=[filter], function=lambda msg: dumps(msg))
 
-sink = KafkaSink(
+sink = StreamSink(
     name="kafkasink",
     ctx=pipeline,
     inputs=[jsonify],
-    logical_topic="transformed-events",
+    stream="transformed-events",
 )

--- a/sentry_streams/sentry_streams/examples/transfomer.py
+++ b/sentry_streams/sentry_streams/examples/transfomer.py
@@ -31,7 +31,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    stream="events",
+    stream_name="events",
 )
 
 parser = Map(name="parser", ctx=pipeline, inputs=[source], function=parse)
@@ -46,5 +46,5 @@ sink = StreamSink(
     name="kafkasink",
     ctx=pipeline,
     inputs=[jsonify],
-    stream="transformed-events",
+    stream_name="transformed-events",
 )

--- a/sentry_streams/sentry_streams/examples/word_counter.py
+++ b/sentry_streams/sentry_streams/examples/word_counter.py
@@ -20,7 +20,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    stream="logical-events",
+    stream_name="logical-events",
 )
 
 filter = Filter(
@@ -55,5 +55,5 @@ sink = StreamSink(
     name="kafkasink",
     ctx=pipeline,
     inputs=[reduce],
-    stream="transformed-events",
+    stream_name="transformed-events",
 )

--- a/sentry_streams/sentry_streams/examples/word_counter.py
+++ b/sentry_streams/sentry_streams/examples/word_counter.py
@@ -7,20 +7,20 @@ from sentry_streams.examples.word_counter_fn import (
 from sentry_streams.pipeline.pipeline import (
     Aggregate,
     Filter,
-    KafkaSink,
-    KafkaSource,
     Map,
     Pipeline,
+    StreamSink,
+    StreamSource,
 )
 from sentry_streams.pipeline.window import TumblingWindow
 
 # pipeline: special name
 pipeline = Pipeline()
 
-source = KafkaSource(
+source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    logical_topic="logical-events",
+    stream="logical-events",
 )
 
 filter = Filter(
@@ -51,9 +51,9 @@ reduce: Aggregate[int, tuple[str, int], str] = Aggregate(
     group_by_key=GroupByWord(),
 )
 
-sink = KafkaSink(
+sink = StreamSink(
     name="kafkasink",
     ctx=pipeline,
     inputs=[reduce],
-    logical_topic="transformed-events",
+    stream="transformed-events",
 )

--- a/sentry_streams/sentry_streams/pipeline/pipeline.py
+++ b/sentry_streams/sentry_streams/pipeline/pipeline.py
@@ -92,7 +92,7 @@ class StreamSource(Source):
     A Source which reads from Kafka.
     """
 
-    stream: str
+    stream_name: str
     step_type: StepType = StepType.SOURCE
 
     def __post_init__(self) -> None:
@@ -128,7 +128,7 @@ class StreamSink(Sink):
     A Sink which specifically writes to Kafka.
     """
 
-    stream: str
+    stream_name: str
     step_type: StepType = StepType.SINK
 
 

--- a/sentry_streams/sentry_streams/pipeline/pipeline.py
+++ b/sentry_streams/sentry_streams/pipeline/pipeline.py
@@ -84,12 +84,12 @@ class Source(Step):
 
 
 @dataclass
-class KafkaSource(Source):
+class StreamSource(Source):
     """
     A Source which reads from Kafka.
     """
 
-    logical_topic: str
+    stream: str
     step_type: StepType = StepType.SOURCE
 
     def __post_init__(self) -> None:
@@ -120,12 +120,12 @@ class Sink(WithInput):
 
 
 @dataclass
-class KafkaSink(Sink):
+class StreamSink(Sink):
     """
     A Sink which specifically writes to Kafka.
     """
 
-    logical_topic: str
+    stream: str
     step_type: StepType = StepType.SINK
 
 

--- a/sentry_streams/tests/adapters/arroyo/conftest.py
+++ b/sentry_streams/tests/adapters/arroyo/conftest.py
@@ -29,7 +29,7 @@ def pipeline() -> Pipeline:
     source = StreamSource(
         name="myinput",
         ctx=pipeline,
-        stream="logical-events",
+        stream_name="logical-events",
     )
     decoder = Map(
         name="decoder",
@@ -50,7 +50,7 @@ def pipeline() -> Pipeline:
         name="kafkasink",
         ctx=pipeline,
         inputs=[map],
-        stream="transformed-events",
+        stream_name="transformed-events",
     )
 
     return pipeline

--- a/sentry_streams/tests/adapters/arroyo/conftest.py
+++ b/sentry_streams/tests/adapters/arroyo/conftest.py
@@ -7,10 +7,10 @@ from arroyo.utils.clock import MockedClock
 
 from sentry_streams.pipeline.pipeline import (
     Filter,
-    KafkaSink,
-    KafkaSource,
     Map,
     Pipeline,
+    StreamSink,
+    StreamSource,
 )
 
 
@@ -26,10 +26,10 @@ def broker() -> LocalBroker[KafkaPayload]:
 @pytest.fixture
 def pipeline() -> Pipeline:
     pipeline = Pipeline()
-    source = KafkaSource(
+    source = StreamSource(
         name="myinput",
         ctx=pipeline,
-        logical_topic="logical-events",
+        stream="logical-events",
     )
     decoder = Map(
         name="decoder",
@@ -46,11 +46,11 @@ def pipeline() -> Pipeline:
         inputs=[filter],
         function=lambda msg: msg + "_mapped",
     )
-    _ = KafkaSink(
+    _ = StreamSink(
         name="kafkasink",
         ctx=pipeline,
         inputs=[map],
-        logical_topic="transformed-events",
+        stream="transformed-events",
     )
 
     return pipeline

--- a/sentry_streams/tests/adapters/arroyo/test_adapter.py
+++ b/sentry_streams/tests/adapters/arroyo/test_adapter.py
@@ -8,12 +8,12 @@ from arroyo.types import Partition, Topic
 from sentry_streams.adapters.arroyo.adapter import (
     ArroyoAdapter,
     KafkaConsumerConfig,
-    KafkaSources,
+    StreamSources,
 )
 from sentry_streams.adapters.stream_adapter import RuntimeTranslator
 from sentry_streams.pipeline.pipeline import (
-    KafkaSource,
     Pipeline,
+    StreamSource,
 )
 from sentry_streams.runner import iterate_edges
 
@@ -30,7 +30,7 @@ def test_kafka_sources() -> None:
     consumers = {
         "source2": mock.Mock(),
     }
-    sources = KafkaSources(sources_config, consumers)
+    sources = StreamSources(sources_config, consumers)
 
     with pytest.raises(KeyError):
         sources.get_consumer("source1")
@@ -40,7 +40,7 @@ def test_kafka_sources() -> None:
         sources.get_topic("source2")
 
     pipeline = Pipeline()
-    sources.add_source(KafkaSource("source1", pipeline, "test_topic"))
+    sources.add_source(StreamSource("source1", pipeline, "test_topic"))
 
     assert sources.get_topic("source1") == Topic("test_topic")
     assert sources.get_consumer("source1") is not None

--- a/sentry_streams/tests/adapters/arroyo/test_consumer.py
+++ b/sentry_streams/tests/adapters/arroyo/test_consumer.py
@@ -12,7 +12,7 @@ from sentry_streams.adapters.arroyo.consumer import (
     ArroyoStreamingFactory,
 )
 from sentry_streams.adapters.arroyo.routes import Route
-from sentry_streams.adapters.arroyo.steps import FilterStep, KafkaSinkStep, MapStep
+from sentry_streams.adapters.arroyo.steps import FilterStep, MapStep, StreamSinkStep
 from sentry_streams.pipeline.pipeline import (
     Filter,
     Map,
@@ -61,7 +61,7 @@ def test_single_route(broker: LocalBroker[KafkaPayload], pipeline: Pipeline) -> 
         )
     )
     consumer.add_step(
-        KafkaSinkStep(
+        StreamSinkStep(
             route=Route(source="source1", waypoints=[]),
             producer=broker.get_producer(),
             topic_name="transformed-events",

--- a/sentry_streams/tests/adapters/arroyo/test_steps.py
+++ b/sentry_streams/tests/adapters/arroyo/test_steps.py
@@ -9,7 +9,7 @@ from arroyo.processing.strategies.abstract import ProcessingStrategy
 from arroyo.types import BrokerValue, FilteredPayload, Message, Partition, Topic
 
 from sentry_streams.adapters.arroyo.routes import Route, RoutedValue
-from sentry_streams.adapters.arroyo.steps import FilterStep, KafkaSinkStep, MapStep
+from sentry_streams.adapters.arroyo.steps import FilterStep, MapStep, StreamSinkStep
 from sentry_streams.pipeline.pipeline import Filter, Map, Pipeline
 
 
@@ -136,7 +136,7 @@ def test_sink() -> None:
 
     next_strategy = mock.Mock(spec=ProcessingStrategy)
     producer = mock.Mock(spec=Producer)
-    strategy = KafkaSinkStep(mapped_route, producer, "test_topic").build(next_strategy)
+    strategy = StreamSinkStep(mapped_route, producer, "test_topic").build(next_strategy)
 
     messages = [
         make_msg("test_val", mapped_route, 0),

--- a/sentry_streams/tests/test_pipeline.py
+++ b/sentry_streams/tests/test_pipeline.py
@@ -22,13 +22,13 @@ def pipeline() -> Pipeline:
     source = StreamSource(
         name="source",
         ctx=pipeline,
-        stream="logical-events",
+        stream_name="logical-events",
     )
 
     source2 = StreamSource(
         name="source2",
         ctx=pipeline,
-        stream="anotehr-logical-events",
+        stream_name="anotehr-logical-events",
     )
 
     filter = Filter(
@@ -74,14 +74,14 @@ def pipeline() -> Pipeline:
         name="kafkasink1",
         ctx=pipeline,
         inputs=[router.routing_table["branch1"]],
-        stream="transformed-events",
+        stream_name="transformed-events",
     )
 
     StreamSink(
         name="kafkasink2",
         ctx=pipeline,
         inputs=[router.routing_table["branch2"]],
-        stream="transformed-events-2",
+        stream_name="transformed-events-2",
     )
     return pipeline
 

--- a/sentry_streams/tests/test_pipeline.py
+++ b/sentry_streams/tests/test_pipeline.py
@@ -5,12 +5,12 @@ import pytest
 from sentry_streams.examples.broadcast import pipeline as broadcast_pipeline
 from sentry_streams.pipeline.pipeline import (
     Filter,
-    KafkaSink,
-    KafkaSource,
     Map,
     Pipeline,
     Step,
     StepType,
+    StreamSink,
+    StreamSource,
     TransformStep,
 )
 
@@ -18,16 +18,16 @@ from sentry_streams.pipeline.pipeline import (
 @pytest.fixture
 def pipeline() -> Pipeline:
     pipeline = Pipeline()
-    source = KafkaSource(
+    source = StreamSource(
         name="source",
         ctx=pipeline,
-        logical_topic="logical-events",
+        stream="logical-events",
     )
 
-    source2 = KafkaSource(
+    source2 = StreamSource(
         name="source2",
         ctx=pipeline,
-        logical_topic="anotehr-logical-events",
+        stream="anotehr-logical-events",
     )
 
     filter = Filter(
@@ -58,11 +58,11 @@ def pipeline() -> Pipeline:
         function=simple_map,
     )
 
-    KafkaSink(
+    StreamSink(
         name="kafkasink",
         ctx=pipeline,
         inputs=[map, map2],
-        logical_topic="transformed-events",
+        stream="transformed-events",
     )
     return pipeline
 

--- a/sentry_streams/tests/test_runner.py
+++ b/sentry_streams/tests/test_runner.py
@@ -4,17 +4,17 @@ from unittest.mock import ANY, MagicMock, call
 import pytest
 
 from sentry_streams.adapters.stream_adapter import RuntimeTranslator
-from sentry_streams.pipeline.pipeline import Filter, KafkaSource, Map, Pipeline
+from sentry_streams.pipeline.pipeline import Filter, Map, Pipeline, StreamSource
 from sentry_streams.runner import iterate_edges
 
 
 @pytest.fixture
 def create_pipeline() -> Pipeline:
     test_pipeline = Pipeline()
-    source1 = KafkaSource(
+    source1 = StreamSource(
         name="source1",
         ctx=test_pipeline,
-        logical_topic="foo",
+        stream="foo",
     )
     step1 = Map(
         name="step1",

--- a/sentry_streams/tests/test_runner.py
+++ b/sentry_streams/tests/test_runner.py
@@ -28,7 +28,7 @@ def create_pipeline() -> Pipeline:
     source1 = StreamSource(
         name="source1",
         ctx=test_pipeline,
-        stream="foo",
+        stream_name="foo",
     )
     map1 = Map(
         name="map1",


### PR DESCRIPTION
Our goal is to provide an abstraction over streams. 
We are hiding all the aspects of Kafka like message, commit policy, partitions etc.
Why having to call a stream source KafkaSource when the user only needs to care of a sterm of events ?
