### PR TITLE
fix: rename Stream/StreamSink generics

### DIFF
--- a/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
@@ -147,7 +147,7 @@ class ArroyoAdapter(StreamAdapter[Route, Route]):
         """
         # TODO: Provide a better way to get the logical stream name from
         # the Sink step. We should not have to assert it is a Kafka sink
-        assert isinstance(step, StreamSink), "Only Kafka Sinks are supported"
+        assert isinstance(step, StreamSink), "Only Stream Sinks are supported"
 
         sink_name = step.name
         if sink_name not in self.__sinks:

--- a/sentry_streams/sentry_streams/runner.py
+++ b/sentry_streams/sentry_streams/runner.py
@@ -6,8 +6,8 @@ from typing import Any, cast
 from sentry_streams.adapters.loader import load_adapter
 from sentry_streams.adapters.stream_adapter import (
     RuntimeTranslator,
-    Stream,
-    StreamSink,
+    StreamSinkT,
+    StreamT,
 )
 from sentry_streams.pipeline.pipeline import (
     Pipeline,
@@ -17,7 +17,7 @@ from sentry_streams.pipeline.pipeline import (
 logger = logging.getLogger(__name__)
 
 
-def iterate_edges(p_graph: Pipeline, translator: RuntimeTranslator[Stream, StreamSink]) -> None:
+def iterate_edges(p_graph: Pipeline, translator: RuntimeTranslator[StreamT, StreamSinkT]) -> None:
     """
     Traverses over edges in a PipelineGraph, building the
     stream incrementally by applying steps and transformations


### PR DESCRIPTION
https://github.com/getsentry/streams/pull/79 caused a name clash with the `StreamSink` generic, this renames the generic types to `StreamT`/`StreamSinkT`

I'll open another PR to fix the imports for the flink adapter