### PR TITLE
Introduce chained primitives to replace the old DSL

### DIFF
--- a/sentry_streams/sentry_streams/examples/batching.py
+++ b/sentry_streams/sentry_streams/examples/batching.py
@@ -1,15 +1,8 @@
 import json
 
+from sentry_streams.pipeline import Batch, FlatMap, Map, streaming_source
 from sentry_streams.pipeline.batch import unbatch
 from sentry_streams.pipeline.function_template import InputType
-from sentry_streams.pipeline.pipeline import (
-    Batch,
-    FlatMap,
-    Map,
-    Pipeline,
-    StreamSink,
-    StreamSource,
-)
 
 
 def build_batch_str(batch: list[InputType]) -> str:
@@ -26,25 +19,16 @@ def build_message_str(message: str) -> str:
     return json.dumps(d)
 
 
-pipeline = Pipeline()
-
-source = StreamSource(
-    name="myinput",
-    ctx=pipeline,
-    stream_name="logical-events",
-)
-
-# User simply provides the batch size
-reduce: Batch[int, str] = Batch(name="mybatch", ctx=pipeline, inputs=[source], batch_size=5)
-
-flat_map = FlatMap(name="myunbatch", ctx=pipeline, inputs=[reduce], function=unbatch)
-
-map = Map(name="mymap", ctx=pipeline, inputs=[flat_map], function=build_message_str)
-
-# flush the batches to the Sink
-sink = StreamSink(
-    name="kafkasink",
-    ctx=pipeline,
-    inputs=[map],
-    stream_name="transformed-events",
+pipeline = (
+    streaming_source(
+        name="myinput",
+        stream_name="logical-events",
+    )
+    .apply("mybatch", Batch(batch_size=5))  # User simply provides the batch size
+    .apply("myunbatch", FlatMap(function=unbatch))
+    .apply("mymap", Map(function=build_message_str))
+    .sink(
+        "kafkasink",
+        stream_name="transformed-events",
+    )  # flush the batches to the Sink
 )

--- a/sentry_streams/sentry_streams/examples/blq.py
+++ b/sentry_streams/sentry_streams/examples/blq.py
@@ -30,7 +30,7 @@ save_delayed_message = (
 pipeline = (
     streaming_source(
         name="ingest",
-        stream_name="logical-events",
+        stream_name="events",
     )
     .apply("unpack_message", Map(unpack_kafka_message))
     .route(

--- a/sentry_streams/sentry_streams/examples/transfomer.py
+++ b/sentry_streams/sentry_streams/examples/transfomer.py
@@ -1,9 +1,9 @@
 from json import JSONDecodeError, dumps, loads
 from typing import Any, Mapping, cast
-from sentry_streams.pipeline import Batch, FlatMap, Map, streaming_source, Filter
+
+from sentry_streams.pipeline import Batch, Filter, FlatMap, Map, streaming_source
 from sentry_streams.pipeline.batch import unbatch
 from sentry_streams.pipeline.function_template import InputType
-
 
 # The simplest possible pipeline.
 # - reads from Kafka

--- a/sentry_streams/sentry_streams/examples/transfomer.py
+++ b/sentry_streams/sentry_streams/examples/transfomer.py
@@ -1,13 +1,9 @@
 from json import JSONDecodeError, dumps, loads
 from typing import Any, Mapping, cast
+from sentry_streams.pipeline import Batch, FlatMap, Map, streaming_source, Filter
+from sentry_streams.pipeline.batch import unbatch
+from sentry_streams.pipeline.function_template import InputType
 
-from sentry_streams.pipeline.pipeline import (
-    Filter,
-    Map,
-    Pipeline,
-    StreamSink,
-    StreamSource,
-)
 
 # The simplest possible pipeline.
 # - reads from Kafka
@@ -26,25 +22,16 @@ def parse(msg: str) -> Mapping[str, Any]:
     return cast(Mapping[str, Any], parsed)
 
 
-pipeline = Pipeline()
-
-source = StreamSource(
-    name="myinput",
-    ctx=pipeline,
-    stream_name="events",
-)
-
-parser = Map(name="parser", ctx=pipeline, inputs=[source], function=parse)
-
-filter = Filter(
-    name="myfilter", ctx=pipeline, inputs=[parser], function=lambda msg: msg["type"] == "event"
-)
-
-jsonify = Map(name="serializer", ctx=pipeline, inputs=[filter], function=lambda msg: dumps(msg))
-
-sink = StreamSink(
-    name="kafkasink",
-    ctx=pipeline,
-    inputs=[jsonify],
-    stream_name="transformed-events",
+pipeline = (
+    streaming_source(
+        name="myinput",
+        stream_name="events",
+    )
+    .apply("mymap", Map(function=parse))
+    .apply("myfilter", Filter(function=lambda msg: msg["type"] == "event"))
+    .apply("serializer", Map(function=lambda msg: dumps(msg)))
+    .sink(
+        "kafkasink",
+        stream_name="transformed-events",
+    )  # flush the batches to the Sink
 )

--- a/sentry_streams/sentry_streams/pipeline/__init__.py
+++ b/sentry_streams/sentry_streams/pipeline/__init__.py
@@ -1,0 +1,19 @@
+from sentry_streams.pipeline.chain import (
+    Batch,
+    Filter,
+    FlatMap,
+    Map,
+    Reducer,
+    segment,
+    streaming_source,
+)
+
+__all__ = [
+    "streaming_source",
+    "segment",
+    "Map",
+    "Filter",
+    "FlatMap",
+    "Reducer",
+    "Batch",
+]

--- a/sentry_streams/sentry_streams/pipeline/chain.py
+++ b/sentry_streams/sentry_streams/pipeline/chain.py
@@ -26,7 +26,7 @@ from sentry_streams.pipeline.pipeline import Batch as BatchStep
 from sentry_streams.pipeline.pipeline import (
     Branch,
 )
-from sentry_streams.pipeline.pipeline import Filter as FitlerStep
+from sentry_streams.pipeline.pipeline import Filter as FilterStep
 from sentry_streams.pipeline.pipeline import FlatMap as FlatMapStep
 from sentry_streams.pipeline.pipeline import Map as MapStep
 from sentry_streams.pipeline.pipeline import (
@@ -80,7 +80,7 @@ class Filter(Applier[TIn, TIn], Generic[TIn]):
     function: Union[Callable[[TIn], bool], str]
 
     def build_step(self, name: str, ctx: Pipeline, previous: Step) -> Step:
-        return FitlerStep(name=name, ctx=ctx, inputs=[previous], function=self.function)
+        return FilterStep(name=name, ctx=ctx, inputs=[previous], function=self.function)
 
 
 @dataclass

--- a/sentry_streams/sentry_streams/pipeline/chain.py
+++ b/sentry_streams/sentry_streams/pipeline/chain.py
@@ -46,8 +46,24 @@ TOut = TypeVar("TOut")
 
 @dataclass
 class Applier(ABC, Generic[TIn, TOut]):
+    """
+    Defines a primitive that can be applied on a stream.
+    Instances of these class represent a step in the pipeline and
+    contains the metadata needed by the adapter to add the step
+    to the pipeline itself.
+
+    This class is primarily syntactic sugar to avoid having tons
+    of methods in the `Chain` class and still allow some customization
+    of the primitives.
+    """
+
     @abstractmethod
     def build_step(self, name: str, ctx: Pipeline, previous: Step) -> Step:
+        """
+        Build a pipeline step and wires it to the Pipeline.
+
+        This method will go away once the old syntax will be retired.
+        """
         raise NotImplementedError
 
 
@@ -110,13 +126,50 @@ class Batch(
         )
 
 
-class TerminatedChain(Pipeline):
+class Chain(Pipeline):
+    """
+    A pipeline that terminates with a branch or a sink. Which means a pipeline
+    we cannot append further steps on.
+
+    This type exists so the type checker can prevent us from reaching an
+    invalid state.
+    """
+
     def __init__(self, name: str) -> None:
         super().__init__()
         self.name = name
 
 
-class Chain(TerminatedChain):
+class ExtensibleChain(Chain):
+    """
+    Defines a streaming pipeline or a segment of a pipeline by chaining
+    operators that define steps via function calls.
+
+    A Chain is a pipeline that starts with a source, follows a number of
+    steps. Some steps are operators that perform processing on a stream.
+    Other steps manage the pipeline topology: sink, broadcast, route.
+
+    Example:
+    ```
+    pipeline = (
+        streaming_source("myinput", "events") # Starts the pipeline
+        .apply("transform1", Map(lambda msg: msg)) # Performs an operation
+        .route( # Branches the pipeline
+            "route_to_one",
+            routing_function=routing_func,
+            routes={
+                Routes.ROUTE1: segment(name="route1") # Creates a branch
+                .apply("transform2", Map(lambda msg: msg))
+                .sink("myoutput1", "transformed-events2"),
+                Routes.ROUTE2: segment(name="route2")
+                .apply("transform3", Map(lambda msg: msg))
+                .sink("myoutput2", "transformed-events3"),
+            },
+        )
+    )
+    ```
+    """
+
     def __init__(self, name: str) -> None:
         super().__init__(name)
         self.__edge: Step | None = None
@@ -124,12 +177,26 @@ class Chain(TerminatedChain):
     def _add_start(self, start: Step) -> None:
         self.__edge = start
 
-    def apply(self, name: str, applier: Applier[TIn, TOut]) -> Chain:
+    def apply(self, name: str, applier: Applier[TIn, TOut]) -> ExtensibleChain:
+        """
+        Apply a transformation to the stream. The transformation is
+        defined via an `Applier`.
+
+        Operations can change the cardinality of the messages in the stream.
+        Examples:
+        - map performs a 1:1 transformation
+        - filter performs a 1:0..1 transformation
+        - flatMap performs a 1:n transformation
+        - reduce performs a n:1 transformation
+        """
         assert self.__edge is not None
         self.__edge = applier.build_step(name, self, self.__edge)
         return self
 
-    def broadcast(self, name: str, routes: Sequence[TerminatedChain]) -> TerminatedChain:
+    def broadcast(self, name: str, routes: Sequence[Chain]) -> Chain:
+        """
+        Forks the pipeline sending all messages to all routes.
+        """
         assert self.__edge is not None
         for chain in routes:
             self.merge(other=chain, merge_point=self.__edge.name)
@@ -139,8 +206,13 @@ class Chain(TerminatedChain):
         self,
         name: str,
         routing_function: Callable[..., TRoute],
-        routes: Mapping[TRoute, TerminatedChain],
-    ) -> TerminatedChain:
+        routes: Mapping[TRoute, Chain],
+    ) -> Chain:
+        """
+        Forks the pipeline sending each message to one of the branches.
+        The `routing_function` parameter specifies the function that
+        takes the message in and returns the route to send it to.
+        """
         assert self.__edge is not None
         table = {branch: Branch(name=chain.name, ctx=self) for branch, chain in routes.items()}
         Router(
@@ -156,20 +228,32 @@ class Chain(TerminatedChain):
 
         return self
 
-    def sink(self, name: str, stream_name: str) -> TerminatedChain:
+    def sink(self, name: str, stream_name: str) -> Chain:
+        """
+        Terminates the pipeline.
+
+        TODO: support anything other than StreamSink.
+        """
         assert self.__edge is not None
         StreamSink(name=name, ctx=self, inputs=[self.__edge], stream_name=stream_name)
         return self
 
 
-def segment(name: str) -> Chain:
-    pipeline: Chain = Chain(name)
+def segment(name: str) -> ExtensibleChain:
+    """
+    Creates a segment of a pipeline to be referenced in existing pipelines
+    in route and broadcast steps.
+    """
+    pipeline: ExtensibleChain = ExtensibleChain(name)
     pipeline._add_start(Branch(name=name, ctx=pipeline))
     return pipeline
 
 
-def streaming_source(name: str, stream_name: str) -> Chain:
-    pipeline: Chain = Chain("root")
+def streaming_source(name: str, stream_name: str) -> ExtensibleChain:
+    """
+    Create a pipeline that starts with a StreamingSource.
+    """
+    pipeline: ExtensibleChain = ExtensibleChain("root")
     source = StreamSource(
         name=name,
         ctx=pipeline,

--- a/sentry_streams/sentry_streams/pipeline/chain.py
+++ b/sentry_streams/sentry_streams/pipeline/chain.py
@@ -261,3 +261,6 @@ def streaming_source(name: str, stream_name: str) -> ExtensibleChain:
     )
     pipeline._add_start(source)
     return pipeline
+
+
+# TODO: Support pipelines with multiple sources.

--- a/sentry_streams/sentry_streams/pipeline/chain.py
+++ b/sentry_streams/sentry_streams/pipeline/chain.py
@@ -1,59 +1,179 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Iterable, Mapping, Sequence, TypeVar, Union
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import (
+    Callable,
+    Generic,
+    Mapping,
+    MutableSequence,
+    Sequence,
+    TypeVar,
+    Union,
+)
 
-from sentry_streams.pipeline.pipeline import KafkaSource, Map, Pipeline, Step
+from sentry_streams.pipeline.function_template import (
+    Accumulator,
+    AggregationBackend,
+    GroupBy,
+    InputType,
+    OutputType,
+)
+from sentry_streams.pipeline.pipeline import (
+    Aggregate,
+)
+from sentry_streams.pipeline.pipeline import Batch as BatchStep
+from sentry_streams.pipeline.pipeline import (
+    Branch,
+)
+from sentry_streams.pipeline.pipeline import Filter as FitlerStep
+from sentry_streams.pipeline.pipeline import FlatMap as FlatMapStep
+from sentry_streams.pipeline.pipeline import Map as MapStep
+from sentry_streams.pipeline.pipeline import (
+    Pipeline,
+    Router,
+    Step,
+    StreamSink,
+    StreamSource,
+)
+from sentry_streams.pipeline.window import MeasurementUnit, Window
 
-T = TypeVar("T")
-function_ref = Union[Callable[..., T], str]
+TRoute = TypeVar("TRoute")
+
+TIn = TypeVar("TIn")
+TOut = TypeVar("TOut")
 
 
-class Reducer:
-    pass
+@dataclass
+class Applier(ABC, Generic[TIn, TOut]):
+    @abstractmethod
+    def build_step(self, name: str, ctx: Pipeline, previous: Step) -> Step:
+        raise NotImplementedError
 
 
-class Chain(Pipeline):
-    def __init__(self) -> None:
+@dataclass
+class Map(Applier[TIn, TOut], Generic[TIn, TOut]):
+    function: Union[Callable[[TIn], TOut], str]
+
+    def build_step(self, name: str, ctx: Pipeline, previous: Step) -> Step:
+        return MapStep(name=name, ctx=ctx, inputs=[previous], function=self.function)
+
+
+@dataclass
+class Filter(Applier[TIn, TIn], Generic[TIn]):
+    function: Union[Callable[[TIn], bool], str]
+
+    def build_step(self, name: str, ctx: Pipeline, previous: Step) -> Step:
+        return FitlerStep(name=name, ctx=ctx, inputs=[previous], function=self.function)
+
+
+@dataclass
+class FlatMap(Applier[TIn, TOut], Generic[TIn, TOut]):
+    function: Union[Callable[[TIn], TOut], str]
+
+    def build_step(self, name: str, ctx: Pipeline, previous: Step) -> Step:
+        return FlatMapStep(name=name, ctx=ctx, inputs=[previous], function=self.function)
+
+
+@dataclass
+class Reducer(Applier[InputType, OutputType], Generic[MeasurementUnit, InputType, OutputType]):
+    window: Window[MeasurementUnit]
+    aggregate_func: Callable[[], Accumulator[InputType, OutputType]]
+    aggregate_backend: AggregationBackend[OutputType] | None = None
+    group_by_key: GroupBy | None = None
+
+    def build_step(self, name: str, ctx: Pipeline, previous: Step) -> Step:
+        return Aggregate(
+            name=name,
+            ctx=ctx,
+            inputs=[previous],
+            window=self.window,
+            aggregate_func=self.aggregate_func,
+            aggregate_backend=self.aggregate_backend,
+            group_by_key=self.group_by_key,
+        )
+
+
+@dataclass
+class Batch(
+    Applier[InputType, MutableSequence[InputType]],
+    Generic[MeasurementUnit, InputType],
+):
+    batch_size: MeasurementUnit
+
+    def build_step(self, name: str, ctx: Pipeline, previous: Step) -> Step:
+        return BatchStep(
+            name=name,
+            ctx=ctx,
+            inputs=[previous],
+            batch_size=self.batch_size,
+        )
+
+
+class TerminatedChain(Pipeline):
+    def __init__(self, name: str) -> None:
+        super().__init__()
+        self.name = name
+
+
+class Chain(TerminatedChain):
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
         self.__edge: Step | None = None
 
     def _add_start(self, start: Step) -> None:
         self.__edge = start
 
-    def map(self, name: str, function: Union[Callable[..., Any], str]) -> Chain:
+    def apply(self, name: str, applier: Applier[TIn, TOut]) -> Chain:
         assert self.__edge is not None
-        self.__edge = Map(name=name, ctx=self, inputs=[self.__edge], function=function)
+        self.__edge = applier.build_step(name, self, self.__edge)
         return self
 
-    def apply(self, name: str, function: Union[Callable[..., Iterable[Any]], str]) -> Chain:
+    def broadcast(self, name: str, routes: Sequence[TerminatedChain]) -> TerminatedChain:
+        assert self.__edge is not None
+        for chain in routes:
+            self.merge(other=chain, merge_point=self.__edge.name)
         return self
 
-    def reduce(self, name: str, reducer: Reducer) -> Chain:
-        return self
-
-    def broadcast(self, name: str, routes: Sequence[Pipeline]) -> Pipeline:
-        return self
-
-    def branch(
+    def route(
         self,
         name: str,
-        routing_function: Union[Callable[..., T], str],
-        routes: Mapping[T, Pipeline],
-    ) -> Pipeline:
+        routing_function: Callable[..., TRoute],
+        routes: Mapping[TRoute, TerminatedChain],
+    ) -> TerminatedChain:
+        assert self.__edge is not None
+        table = {branch: Branch(name=chain.name, ctx=self) for branch, chain in routes.items()}
+        Router(
+            name,
+            ctx=self,
+            inputs=[self.__edge],
+            routing_function=routing_function,
+            routing_table=table,
+        )
+        for branch in table:
+            chain = routes[branch]
+            self.merge(other=chain, merge_point=chain.name)
+
         return self
 
-    def sink(self) -> Pipeline:
+    def sink(self, name: str, stream_name: str) -> TerminatedChain:
+        assert self.__edge is not None
+        StreamSink(name=name, ctx=self, inputs=[self.__edge], stream_name=stream_name)
         return self
 
 
-def branch() -> Chain:
-    pass
+def segment(name: str) -> Chain:
+    pipeline: Chain = Chain(name)
+    pipeline._add_start(Branch(name=name, ctx=pipeline))
+    return pipeline
 
 
-def streaming_source(name: str, logical_topic: str) -> Chain:
-    pipeline = Chain()
-    KafkaSource(
+def streaming_source(name: str, stream_name: str) -> Chain:
+    pipeline: Chain = Chain("root")
+    source = StreamSource(
         name=name,
         ctx=pipeline,
-        logical_topic=logical_topic,
+        stream_name=stream_name,
     )
+    pipeline._add_start(source)
     return pipeline

--- a/sentry_streams/sentry_streams/pipeline/chain.py
+++ b/sentry_streams/sentry_streams/pipeline/chain.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from sentry_streams.pipeline.pipeline import Pipeline, KafkaSource, Step, Map
+from typing import Union, Callable, TypeVar, Any, Sequence, Mapping, Iterable
+
+T = TypeVar("T")
+function_ref = Union[Callable[..., T], str]
+
+
+class Reducer:
+    pass
+
+
+class Chain(Pipeline):
+    def __init__(self) -> None:
+        self.__edge: Step | None = None
+
+    def _add_start(self, start: Step) -> None:
+        self.__edge = start
+
+    def map(self, name: str, function: Union[Callable[..., Any], str]) -> Chain:
+        assert self.__edge is not None
+        self.__edge = Map(name=name, ctx=self, inputs=[self.__edge], function=function)
+        return self
+
+    def apply(self, name: str, function: Union[Callable[..., Iterable[Any]], str]) -> Chain:
+        return self
+
+    def reduce(self, name: str, reducer: Reducer) -> Chain:
+        return self
+
+    def broadcast(self, name: str, routes: Sequence[Pipeline]) -> Pipeline:
+        return self
+
+    def branch(
+        self,
+        name: str,
+        routing_function: Union[Callable[..., T], str],
+        routes: Mapping[T, Pipeline],
+    ) -> Pipeline:
+        return self
+
+    def sink(self) -> Pipeline:
+        return self
+
+
+def branch() -> Chain:
+    pass
+
+
+def streaming_source(name: str, logical_topic: str) -> Chain:
+    pipeline = Chain()
+    KafkaSource(
+        name=name,
+        ctx=pipeline,
+        logical_topic=logical_topic,
+    )
+    return pipeline

--- a/sentry_streams/sentry_streams/pipeline/chain.py
+++ b/sentry_streams/sentry_streams/pipeline/chain.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from sentry_streams.pipeline.pipeline import Pipeline, KafkaSource, Step, Map
-from typing import Union, Callable, TypeVar, Any, Sequence, Mapping, Iterable
+from typing import Any, Callable, Iterable, Mapping, Sequence, TypeVar, Union
+
+from sentry_streams.pipeline.pipeline import KafkaSource, Map, Pipeline, Step
 
 T = TypeVar("T")
 function_ref = Union[Callable[..., T], str]

--- a/sentry_streams/tests/pipeline/test_chain.py
+++ b/sentry_streams/tests/pipeline/test_chain.py
@@ -1,0 +1,187 @@
+from enum import Enum
+from typing import Any, TypeVar, cast
+from unittest import mock
+
+import pytest
+
+from sentry_streams.pipeline.chain import (
+    Applier,
+    Batch,
+    Filter,
+    FlatMap,
+    Map,
+    Reducer,
+    segment,
+    streaming_source,
+)
+from sentry_streams.pipeline.pipeline import (
+    Pipeline,
+    StreamSource,
+    make_edge_sets,
+)
+from sentry_streams.pipeline.window import TumblingWindow
+
+
+def test_sequence() -> None:
+    pipeline = (
+        streaming_source("myinput", "events")
+        .apply("transform1", Map(lambda msg: msg))
+        .sink("myoutput", "transformed-events")
+    )
+
+    assert set(pipeline.steps.keys()) == {"myinput", "transform1", "myoutput"}
+    assert cast(StreamSource, pipeline.steps["myinput"]).stream_name == "events"
+    assert pipeline.steps["myinput"].ctx == pipeline
+    assert set(s.name for s in pipeline.sources) == {"myinput"}
+
+    assert pipeline.steps["transform1"].name == "transform1"
+    assert pipeline.steps["transform1"].ctx == pipeline
+
+    assert pipeline.steps["myoutput"].name == "myoutput"
+    assert pipeline.steps["myoutput"].ctx == pipeline
+
+    assert pipeline.incoming_edges["myinput"] == []
+    assert pipeline.incoming_edges["transform1"] == ["myinput"]
+    assert pipeline.incoming_edges["myoutput"] == ["transform1"]
+
+    assert pipeline.outgoing_edges["myinput"] == ["transform1"]
+    assert pipeline.outgoing_edges["transform1"] == ["myoutput"]
+    assert pipeline.outgoing_edges["myoutput"] == []
+
+
+def test_broadcast() -> None:
+    pipeline = (
+        streaming_source("myinput", "events")
+        .apply("transform1", Map(lambda msg: msg))
+        .broadcast(
+            "route_to_all",
+            [
+                segment(name="route1")
+                .apply("transform2", Map(lambda msg: msg))
+                .sink("myoutput1", "transformed-events2"),
+                segment(name="route2")
+                .apply("transform3", Map(lambda msg: msg))
+                .sink("myoutput2", "transformed-events3"),
+            ],
+        )
+    )
+
+    assert set(pipeline.steps.keys()) == {
+        "myinput",
+        "transform1",
+        "transform2",
+        "myoutput1",
+        "transform3",
+        "myoutput2",
+    }
+
+    assert make_edge_sets(pipeline.incoming_edges) == {
+        "transform1": {"myinput"},
+        "transform2": {"transform1"},
+        "myoutput1": {"transform2"},
+        "transform3": {"transform1"},
+        "myoutput2": {"transform3"},
+    }
+
+    assert make_edge_sets(pipeline.outgoing_edges) == {
+        "myinput": {"transform1"},
+        "transform1": {"transform2", "transform3"},
+        "transform2": {"myoutput1"},
+        "transform3": {"myoutput2"},
+    }
+
+
+class Routes(Enum):
+    ROUTE1 = "route1"
+    ROUTE2 = "route2"
+
+
+def routing_func(msg: Any) -> Routes:
+    return Routes.ROUTE1
+
+
+def test_router() -> None:
+    pipeline = (
+        streaming_source("myinput", "events")
+        .apply("transform1", Map(lambda msg: msg))
+        .route(
+            "route_to_one",
+            routing_function=routing_func,
+            routes={
+                Routes.ROUTE1: segment(name="route1")
+                .apply("transform2", Map(lambda msg: msg))
+                .sink("myoutput1", "transformed-events2"),
+                Routes.ROUTE2: segment(name="route2")
+                .apply("transform3", Map(lambda msg: msg))
+                .sink("myoutput2", "transformed-events3"),
+            },
+        )
+    )
+
+    assert set(pipeline.steps.keys()) == {
+        "myinput",
+        "transform1",
+        "route_to_one",
+        "route1",
+        "transform2",
+        "myoutput1",
+        "route2",
+        "transform3",
+        "myoutput2",
+    }
+
+    assert make_edge_sets(pipeline.incoming_edges) == {
+        "transform1": {"myinput"},
+        "route_to_one": {"transform1"},
+        "route1": {"route_to_one"},
+        "transform2": {"route1"},
+        "myoutput1": {"transform2"},
+        "route2": {"route_to_one"},
+        "transform3": {"route2"},
+        "myoutput2": {"transform3"},
+    }
+
+    assert make_edge_sets(pipeline.outgoing_edges) == {
+        "myinput": {"transform1"},
+        "transform1": {"route_to_one"},
+        "route_to_one": {"route1", "route2"},
+        "route1": {"transform2"},
+        "transform2": {"myoutput1"},
+        "route2": {"transform3"},
+        "transform3": {"myoutput2"},
+    }
+
+
+TIn = TypeVar("TIn")
+TOut = TypeVar("TOut")
+
+
+@pytest.mark.parametrize(
+    "applier, name",
+    [
+        pytest.param(Map(lambda msg: msg), "map_step", id="Create map"),
+        pytest.param(Filter(lambda msg: True), "filter_step", id="Create filter"),
+        pytest.param(FlatMap(lambda msg: [msg]), "flatmap_step", id="Create flatMap"),
+        pytest.param(
+            Reducer(
+                window=TumblingWindow(window_size=1),
+                aggregate_func=lambda: mock.Mock(),
+            ),
+            "reducer_step",
+            id="Create reducer",
+        ),
+        pytest.param(Batch(batch_size=1), "batch_step", id="Create batch"),
+    ],
+)
+def test_applier_steps(applier: Applier[TIn, TOut], name: str) -> None:
+    pipeline = Pipeline()
+    source = StreamSource(
+        name="mysource",
+        ctx=pipeline,
+        stream_name="name",
+    )
+    ret = applier.build_step(name, pipeline, source)
+    assert pipeline.steps[name] == ret
+    assert pipeline.steps[name].name == name
+    assert pipeline.incoming_edges[name] == ["mysource"]
+    assert pipeline.outgoing_edges["mysource"] == [name]

--- a/sentry_streams/tests/test_pipeline.py
+++ b/sentry_streams/tests/test_pipeline.py
@@ -13,6 +13,7 @@ from sentry_streams.pipeline.pipeline import (
     StreamSink,
     StreamSource,
     TransformStep,
+    make_edge_sets,
 )
 
 
@@ -166,3 +167,117 @@ def test_resolve_function(
         step_type=StepType.MAP,
     )
     assert step.resolved_function == expected
+
+
+def test_merge_linear() -> None:
+    pipeline1 = Pipeline()
+    StreamSource(
+        name="source",
+        ctx=pipeline1,
+        stream_name="logical-events",
+    )
+
+    pipeline2 = Pipeline()
+    branch = Branch(
+        "branch1",
+        pipeline2,
+    )
+    Map(
+        name="map",
+        ctx=pipeline2,
+        inputs=[branch],
+        function=simple_map,
+    )
+
+    pipeline1.merge(pipeline2, merge_point="source")
+
+    assert set(pipeline1.steps.keys()) == {"source", "map"}
+    assert pipeline1.outgoing_edges == {
+        "source": ["map"],
+    }
+    assert pipeline1.incoming_edges == {
+        "map": ["source"],
+    }
+
+
+def test_merge_branches() -> None:
+    pipeline1 = Pipeline()
+    StreamSource(
+        name="source",
+        ctx=pipeline1,
+        stream_name="logical-events",
+    )
+
+    pipeline2 = Pipeline()
+    branch1 = Branch(
+        "branch1",
+        pipeline2,
+    )
+    Map(
+        name="map1",
+        ctx=pipeline2,
+        inputs=[branch1],
+        function=simple_map,
+    )
+
+    pipeline3 = Pipeline()
+    branch2 = Branch(
+        "branch2",
+        pipeline3,
+    )
+    Map(
+        name="map2",
+        ctx=pipeline3,
+        inputs=[branch2],
+        function=simple_map,
+    )
+
+    pipeline1.merge(pipeline2, merge_point="source")
+    pipeline1.merge(pipeline3, merge_point="source")
+
+    assert set(pipeline1.steps.keys()) == {"source", "map1", "map2"}
+    assert make_edge_sets(pipeline1.outgoing_edges) == {
+        "source": {"map1", "map2"},
+    }
+    assert make_edge_sets(pipeline1.incoming_edges) == {
+        "map1": {"source"},
+        "map2": {"source"},
+    }
+
+
+def test_multi_broadcast() -> None:
+    pipeline1 = Pipeline()
+    StreamSource(
+        name="source",
+        ctx=pipeline1,
+        stream_name="logical-events",
+    )
+
+    pipeline2 = Pipeline()
+    branch1 = Branch(
+        "branch1",
+        pipeline2,
+    )
+    Map(
+        name="map1",
+        ctx=pipeline2,
+        inputs=[branch1],
+        function=simple_map,
+    )
+    Map(
+        name="map2",
+        ctx=pipeline2,
+        inputs=[branch1],
+        function=simple_map,
+    )
+
+    pipeline1.merge(pipeline2, merge_point="source")
+
+    assert set(pipeline1.steps.keys()) == {"source", "map1", "map2"}
+    assert make_edge_sets(pipeline1.outgoing_edges) == {
+        "source": {"map1", "map2"},
+    }
+    assert make_edge_sets(pipeline1.incoming_edges) == {
+        "map1": {"source"},
+        "map2": {"source"},
+    }

--- a/sentry_streams/uv.lock
+++ b/sentry_streams/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11"
 
 [[package]]
@@ -331,7 +330,7 @@ wheels = [
 
 [[package]]
 name = "sentry-streams"
-version = "0.0.11"
+version = "0.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
The team discussed multiple options on how to represent pipelines in the python DSL.
The winning option was to use a Flink like chaining syntax that has a few advantages:
- It makes the topology evident as each step is chained to the previous one as a
  function call on the return value of the previous one.
- It makes routing and broadcasting much easier.


This PR introduces the DSL and supports all the existing primitives.
Please see the example to see how the syntax looks like.

The transition will be done in three stages:
- This one introduces the new DSL as a way to produce the existing pipeline data structure.
  The chained DSL would introduce fundamental changes to the translator. It becomes
  easier. But I cannto change that as well in this PR
- Port all the examples. I ported two here.
- Replace the translator with one designed for this DSL and update the adapters.

Functionally, what is still missing (will do in a separate PR) is supporting
multi-source pipelines. Now multiple pipeline objects would be created.
