### PR TITLE
ref: remove topics mapping from env config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ python sentry_streams/runner.py \
     -n test \
     -b localhost:9092 \
     -a arroyo \
-    sentry_streams/examples/transfomer.py
+    sentry_streams/examples/transformer.py
 ```
 
 This will start an Arroyo consumer that runs the streaming application defined
-in `sentry_streams/examples/transfomer.py`.
+in `sentry_streams/examples/transformer.py`.
 
 there is a number of examples in the `sentry_streams/examples` directory.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ python sentry_streams/runner.py \
     -n test \
     -b localhost:9092 \
     -a arroyo \
-    sentry_streams/examples/transformer.py
+    sentry_streams/examples/transfomer.py
 ```
 
 This will start an Arroyo consumer that runs the streaming application defined
-in `sentry_streams/examples/transformer.py`.
+in `sentry_streams/examples/transfomer.py`.
 
 there is a number of examples in the `sentry_streams/examples` directory.

--- a/sentry_flink/sentry_flink/flink/flink_adapter.py
+++ b/sentry_flink/sentry_flink/flink/flink_adapter.py
@@ -96,7 +96,7 @@ class FlinkAdapter(StreamAdapter[DataStream, DataStreamSink]):
 
         # TODO: Look into using KafkaSource instead
         kafka_consumer = FlinkKafkaConsumer(
-            topics=self.environment_config["topics"][topic],
+            topics=topic,
             deserialization_schema=deserialization_schema,
             properties={
                 "bootstrap.servers": self.environment_config["broker"],
@@ -116,7 +116,7 @@ class FlinkAdapter(StreamAdapter[DataStream, DataStreamSink]):
             .set_record_serializer(
                 KafkaRecordSerializationSchema.builder()
                 .set_topic(
-                    self.environment_config["topics"][topic],
+                    topic,
                 )
                 .set_value_serialization_schema(SimpleStringSchema())
                 .build()

--- a/sentry_flink/tests/test_pipeline.py
+++ b/sentry_flink/tests/test_pipeline.py
@@ -39,7 +39,7 @@ def setup_basic_flink_env() -> (
     # TODO: read from yaml file
     environment_config = {
         "topics": {
-            "logical-events": "events",
+            "events": "events",
             "transformed-events": "transformed-events",
             "transformed-events-2": "transformed-events-2",
         },
@@ -59,7 +59,7 @@ def basic() -> tuple[Pipeline, MutableMapping[str, list[dict[str, Any]]]]:
     source = StreamSource(
         name="myinput",
         ctx=pipeline,
-        stream_name="logical-events",
+        stream_name="events",
     )
 
     _ = StreamSink(
@@ -106,7 +106,7 @@ def basic_map() -> tuple[Pipeline, MutableMapping[str, list[dict[str, Any]]]]:
     source = StreamSource(
         name="myinput",
         ctx=pipeline,
-        stream_name="logical-events",
+        stream_name="events",
     )
 
     map = Map(
@@ -168,7 +168,7 @@ def basic_filter() -> tuple[Pipeline, MutableMapping[str, list[dict[str, Any]]]]
     source = StreamSource(
         name="myinput",
         ctx=pipeline,
-        stream_name="logical-events",
+        stream_name="events",
     )
 
     filter = Filter(
@@ -230,7 +230,7 @@ def basic_map_reduce() -> tuple[Pipeline, MutableMapping[str, list[dict[str, Any
     source = StreamSource(
         name="myinput",
         ctx=pipeline,
-        stream_name="logical-events",
+        stream_name="events",
     )
 
     map = Map(
@@ -357,7 +357,7 @@ def basic_router() -> tuple[Pipeline, MutableMapping[str, list[dict[str, Any]]]]
     source = StreamSource(
         name="myinput",
         ctx=pipeline,
-        stream_name="logical-events",
+        stream_name="events",
     )
 
     map = Map(
@@ -529,7 +529,7 @@ def bad_import_map() -> Pipeline:
     source = StreamSource(
         name="myinput",
         ctx=pipeline,
-        stream_name="logical-events",
+        stream_name="events",
     )
 
     map = Map(

--- a/sentry_flink/tests/test_pipeline.py
+++ b/sentry_flink/tests/test_pipeline.py
@@ -39,7 +39,7 @@ def setup_basic_flink_env() -> (
     # TODO: read from yaml file
     environment_config = {
         "topics": {
-            "events": "events",
+            "logical-events": "events",
             "transformed-events": "transformed-events",
             "transformed-events-2": "transformed-events-2",
         },
@@ -59,7 +59,7 @@ def basic() -> tuple[Pipeline, MutableMapping[str, list[dict[str, Any]]]]:
     source = StreamSource(
         name="myinput",
         ctx=pipeline,
-        stream_name="events",
+        stream_name="logical-events",
     )
 
     _ = StreamSink(
@@ -106,7 +106,7 @@ def basic_map() -> tuple[Pipeline, MutableMapping[str, list[dict[str, Any]]]]:
     source = StreamSource(
         name="myinput",
         ctx=pipeline,
-        stream_name="events",
+        stream_name="logical-events",
     )
 
     map = Map(
@@ -168,7 +168,7 @@ def basic_filter() -> tuple[Pipeline, MutableMapping[str, list[dict[str, Any]]]]
     source = StreamSource(
         name="myinput",
         ctx=pipeline,
-        stream_name="events",
+        stream_name="logical-events",
     )
 
     filter = Filter(
@@ -230,7 +230,7 @@ def basic_map_reduce() -> tuple[Pipeline, MutableMapping[str, list[dict[str, Any
     source = StreamSource(
         name="myinput",
         ctx=pipeline,
-        stream_name="events",
+        stream_name="logical-events",
     )
 
     map = Map(
@@ -357,7 +357,7 @@ def basic_router() -> tuple[Pipeline, MutableMapping[str, list[dict[str, Any]]]]
     source = StreamSource(
         name="myinput",
         ctx=pipeline,
-        stream_name="events",
+        stream_name="logical-events",
     )
 
     map = Map(
@@ -529,7 +529,7 @@ def bad_import_map() -> Pipeline:
     source = StreamSource(
         name="myinput",
         ctx=pipeline,
-        stream_name="events",
+        stream_name="logical-events",
     )
 
     map = Map(

--- a/sentry_streams/sentry_streams/examples/alerts.py
+++ b/sentry_streams/sentry_streams/examples/alerts.py
@@ -23,7 +23,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    stream_name="logical-events",
+    stream_name="events",
 )
 
 map = Map(

--- a/sentry_streams/sentry_streams/examples/alerts.py
+++ b/sentry_streams/sentry_streams/examples/alerts.py
@@ -23,7 +23,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    stream_name="events",
+    stream_name="logical-events",
 )
 
 map = Map(

--- a/sentry_streams/sentry_streams/examples/batching.py
+++ b/sentry_streams/sentry_streams/examples/batching.py
@@ -13,12 +13,14 @@ from sentry_streams.pipeline.pipeline import (
 
 
 def build_batch_str(batch: list[InputType]) -> str:
+
     d = {"batch": batch}
 
     return json.dumps(d)
 
 
 def build_message_str(message: str) -> str:
+
     d = {"message": message}
 
     return json.dumps(d)
@@ -29,7 +31,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    stream_name="events",
+    stream_name="logical-events",
 )
 
 # User simply provides the batch size

--- a/sentry_streams/sentry_streams/examples/batching.py
+++ b/sentry_streams/sentry_streams/examples/batching.py
@@ -13,14 +13,12 @@ from sentry_streams.pipeline.pipeline import (
 
 
 def build_batch_str(batch: list[InputType]) -> str:
-
     d = {"batch": batch}
 
     return json.dumps(d)
 
 
 def build_message_str(message: str) -> str:
-
     d = {"message": message}
 
     return json.dumps(d)
@@ -31,7 +29,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    stream_name="logical-events",
+    stream_name="events",
 )
 
 # User simply provides the batch size

--- a/sentry_streams/sentry_streams/examples/billing.py
+++ b/sentry_streams/sentry_streams/examples/billing.py
@@ -15,7 +15,6 @@ Outcome = dict[str, str]
 
 
 def build_outcome(value: str) -> Outcome:
-
     d: Outcome = json.loads(value)
 
     return d
@@ -27,7 +26,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    stream_name="logical-events",
+    stream_name="events",
 )
 
 map = Map(

--- a/sentry_streams/sentry_streams/examples/billing.py
+++ b/sentry_streams/sentry_streams/examples/billing.py
@@ -15,6 +15,7 @@ Outcome = dict[str, str]
 
 
 def build_outcome(value: str) -> Outcome:
+
     d: Outcome = json.loads(value)
 
     return d
@@ -26,7 +27,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    stream_name="events",
+    stream_name="logical-events",
 )
 
 map = Map(

--- a/sentry_streams/sentry_streams/examples/blq.py
+++ b/sentry_streams/sentry_streams/examples/blq.py
@@ -19,7 +19,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="ingest",
     ctx=pipeline,
-    stream_name="events",
+    stream_name="logical-events",
 )
 
 unpack_msg = Map(

--- a/sentry_streams/sentry_streams/examples/blq.py
+++ b/sentry_streams/sentry_streams/examples/blq.py
@@ -65,12 +65,12 @@ clickhouse_sink = StreamSink(
     name="clickhouse_sinkStreamSource",
     ctx=pipeline,
     inputs=[dump_msg_recent],
-    stream_name="transformed-eventStreamSource-2",
+    stream_name="transformed-events-2",
 )
 
 delayed_msg_sink = StreamSink(
     name="delayed_msg_sinkStreamSource",
     ctx=pipeline,
     inputs=[dump_msg_delayed],
-    stream_name="transformed-eventStreamSourceStreamSource",
+    stream_name="transformed-events-3",
 )

--- a/sentry_streams/sentry_streams/examples/blq.py
+++ b/sentry_streams/sentry_streams/examples/blq.py
@@ -19,7 +19,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="ingest",
     ctx=pipeline,
-    stream_name="logical-events",
+    stream_name="events",
 )
 
 unpack_msg = Map(

--- a/sentry_streams/sentry_streams/examples/broadcast.py
+++ b/sentry_streams/sentry_streams/examples/broadcast.py
@@ -11,7 +11,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    stream_name="logical-events",
+    stream_name="events",
 )
 
 map = Map(

--- a/sentry_streams/sentry_streams/examples/broadcast.py
+++ b/sentry_streams/sentry_streams/examples/broadcast.py
@@ -11,7 +11,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    stream_name="events",
+    stream_name="logical-events",
 )
 
 map = Map(

--- a/sentry_streams/sentry_streams/examples/spans_buffer.py
+++ b/sentry_streams/sentry_streams/examples/spans_buffer.py
@@ -15,7 +15,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    stream_name="logical-events",
+    stream_name="events",
 )
 
 map = Map(

--- a/sentry_streams/sentry_streams/examples/spans_buffer.py
+++ b/sentry_streams/sentry_streams/examples/spans_buffer.py
@@ -15,7 +15,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    stream_name="events",
+    stream_name="logical-events",
 )
 
 map = Map(

--- a/sentry_streams/sentry_streams/examples/word_counter.py
+++ b/sentry_streams/sentry_streams/examples/word_counter.py
@@ -20,7 +20,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    stream_name="logical-events",
+    stream_name="events",
 )
 
 filter = Filter(

--- a/sentry_streams/sentry_streams/examples/word_counter.py
+++ b/sentry_streams/sentry_streams/examples/word_counter.py
@@ -20,7 +20,7 @@ pipeline = Pipeline()
 source = StreamSource(
     name="myinput",
     ctx=pipeline,
-    stream_name="events",
+    stream_name="logical-events",
 )
 
 filter = Filter(

--- a/sentry_streams/sentry_streams/runner.py
+++ b/sentry_streams/sentry_streams/runner.py
@@ -112,7 +112,7 @@ def main() -> None:
     # TODO: read from yaml file
     environment_config = {
         "topics": {
-            "events": "events",
+            "logical-events": "events",
             "transformed-events": "transformed-events",
             "transformed-events-2": "transformed-events-2",
             "transformed-events-3": "transformed-events-3",

--- a/sentry_streams/sentry_streams/runner.py
+++ b/sentry_streams/sentry_streams/runner.py
@@ -112,7 +112,7 @@ def main() -> None:
     # TODO: read from yaml file
     environment_config = {
         "topics": {
-            "logical-events": "events",
+            "events": "events",
             "transformed-events": "transformed-events",
             "transformed-events-2": "transformed-events-2",
             "transformed-events-3": "transformed-events-3",

--- a/sentry_streams/sentry_streams/runner.py
+++ b/sentry_streams/sentry_streams/runner.py
@@ -111,12 +111,6 @@ def main() -> None:
 
     # TODO: read from yaml file
     environment_config = {
-        "topics": {
-            "events": "events",
-            "transformed-events": "transformed-events",
-            "transformed-events-2": "transformed-events-2",
-            "transformed-events-3": "transformed-events-3",
-        },
         "broker": args.broker,
         "sources_config": {
             "myinput": {

--- a/sentry_streams/tests/adapters/arroyo/conftest.py
+++ b/sentry_streams/tests/adapters/arroyo/conftest.py
@@ -18,7 +18,7 @@ from sentry_streams.pipeline.pipeline import (
 def broker() -> LocalBroker[KafkaPayload]:
     storage: MemoryMessageStorage[KafkaPayload] = MemoryMessageStorage()
     broker = LocalBroker(storage, MockedClock())
-    broker.create_topic(Topic("logical-events"), 1)
+    broker.create_topic(Topic("events"), 1)
     broker.create_topic(Topic("transformed-events"), 1)
     return broker
 
@@ -29,7 +29,7 @@ def pipeline() -> Pipeline:
     source = StreamSource(
         name="myinput",
         ctx=pipeline,
-        stream_name="logical-events",
+        stream_name="events",
     )
     decoder = Map(
         name="decoder",

--- a/sentry_streams/tests/adapters/arroyo/conftest.py
+++ b/sentry_streams/tests/adapters/arroyo/conftest.py
@@ -18,7 +18,7 @@ from sentry_streams.pipeline.pipeline import (
 def broker() -> LocalBroker[KafkaPayload]:
     storage: MemoryMessageStorage[KafkaPayload] = MemoryMessageStorage()
     broker = LocalBroker(storage, MockedClock())
-    broker.create_topic(Topic("events"), 1)
+    broker.create_topic(Topic("logical-events"), 1)
     broker.create_topic(Topic("transformed-events"), 1)
     return broker
 
@@ -29,7 +29,7 @@ def pipeline() -> Pipeline:
     source = StreamSource(
         name="myinput",
         ctx=pipeline,
-        stream_name="events",
+        stream_name="logical-events",
     )
     decoder = Map(
         name="decoder",

--- a/sentry_streams/tests/adapters/arroyo/test_adapter.py
+++ b/sentry_streams/tests/adapters/arroyo/test_adapter.py
@@ -47,12 +47,13 @@ def test_kafka_sources() -> None:
 
 
 def test_adapter(broker: LocalBroker[KafkaPayload], pipeline: Pipeline) -> None:
+
     adapter = ArroyoAdapter.build(
         {
             "sources_config": {},
             "sinks_config": {},
             "sources_override": {
-                "myinput": broker.get_consumer("events"),
+                "myinput": broker.get_consumer("logical-events"),
             },
             "sinks_override": {
                 "kafkasink": broker.get_producer(),
@@ -65,14 +66,14 @@ def test_adapter(broker: LocalBroker[KafkaPayload], pipeline: Pipeline) -> None:
     processor = adapter.get_processor("myinput")
 
     broker.produce(
-        Partition(Topic("events"), 0), KafkaPayload(None, "go_ahead".encode("utf-8"), [])
+        Partition(Topic("logical-events"), 0), KafkaPayload(None, "go_ahead".encode("utf-8"), [])
     )
     broker.produce(
-        Partition(Topic("events"), 0),
+        Partition(Topic("logical-events"), 0),
         KafkaPayload(None, "do_not_go_ahead".encode("utf-8"), []),
     )
     broker.produce(
-        Partition(Topic("events"), 0), KafkaPayload(None, "go_ahead".encode("utf-8"), [])
+        Partition(Topic("logical-events"), 0), KafkaPayload(None, "go_ahead".encode("utf-8"), [])
     )
 
     processor._run_once()

--- a/sentry_streams/tests/adapters/arroyo/test_adapter.py
+++ b/sentry_streams/tests/adapters/arroyo/test_adapter.py
@@ -47,13 +47,12 @@ def test_kafka_sources() -> None:
 
 
 def test_adapter(broker: LocalBroker[KafkaPayload], pipeline: Pipeline) -> None:
-
     adapter = ArroyoAdapter.build(
         {
             "sources_config": {},
             "sinks_config": {},
             "sources_override": {
-                "myinput": broker.get_consumer("logical-events"),
+                "myinput": broker.get_consumer("events"),
             },
             "sinks_override": {
                 "kafkasink": broker.get_producer(),
@@ -66,14 +65,14 @@ def test_adapter(broker: LocalBroker[KafkaPayload], pipeline: Pipeline) -> None:
     processor = adapter.get_processor("myinput")
 
     broker.produce(
-        Partition(Topic("logical-events"), 0), KafkaPayload(None, "go_ahead".encode("utf-8"), [])
+        Partition(Topic("events"), 0), KafkaPayload(None, "go_ahead".encode("utf-8"), [])
     )
     broker.produce(
-        Partition(Topic("logical-events"), 0),
+        Partition(Topic("events"), 0),
         KafkaPayload(None, "do_not_go_ahead".encode("utf-8"), []),
     )
     broker.produce(
-        Partition(Topic("logical-events"), 0), KafkaPayload(None, "go_ahead".encode("utf-8"), [])
+        Partition(Topic("events"), 0), KafkaPayload(None, "go_ahead".encode("utf-8"), [])
     )
 
     processor._run_once()

--- a/sentry_streams/tests/adapters/arroyo/test_consumer.py
+++ b/sentry_streams/tests/adapters/arroyo/test_consumer.py
@@ -70,11 +70,11 @@ def test_single_route(broker: LocalBroker[KafkaPayload], pipeline: Pipeline) -> 
 
     factory = ArroyoStreamingFactory(consumer)
     commit = mock.Mock(spec=Commit)
-    strategy = factory.create_with_partitions(commit, {Partition(Topic("logical-events"), 0): 0})
+    strategy = factory.create_with_partitions(commit, {Partition(Topic("events"), 0): 0})
 
-    strategy.submit(make_msg("go_ahead", "logical-events", 0))
-    strategy.submit(make_msg("do_not_go_ahead", "logical-events", 2))
-    strategy.submit(make_msg("go_ahead", "logical-events", 3))
+    strategy.submit(make_msg("go_ahead", "events", 0))
+    strategy.submit(make_msg("do_not_go_ahead", "events", 2))
+    strategy.submit(make_msg("go_ahead", "events", 3))
     strategy.poll()
 
     topic = Topic("transformed-events")
@@ -87,10 +87,10 @@ def test_single_route(broker: LocalBroker[KafkaPayload], pipeline: Pipeline) -> 
     commit.assert_has_calls(
         [
             call({}),
-            call({Partition(Topic("logical-events"), 0): 1}),
+            call({Partition(Topic("events"), 0): 1}),
             call({}),
-            call({Partition(Topic("logical-events"), 0): 3}),
+            call({Partition(Topic("events"), 0): 3}),
             call({}),
-            call({Partition(Topic("logical-events"), 0): 4}),
+            call({Partition(Topic("events"), 0): 4}),
         ]
     )

--- a/sentry_streams/tests/adapters/arroyo/test_consumer.py
+++ b/sentry_streams/tests/adapters/arroyo/test_consumer.py
@@ -70,11 +70,11 @@ def test_single_route(broker: LocalBroker[KafkaPayload], pipeline: Pipeline) -> 
 
     factory = ArroyoStreamingFactory(consumer)
     commit = mock.Mock(spec=Commit)
-    strategy = factory.create_with_partitions(commit, {Partition(Topic("events"), 0): 0})
+    strategy = factory.create_with_partitions(commit, {Partition(Topic("logical-events"), 0): 0})
 
-    strategy.submit(make_msg("go_ahead", "events", 0))
-    strategy.submit(make_msg("do_not_go_ahead", "events", 2))
-    strategy.submit(make_msg("go_ahead", "events", 3))
+    strategy.submit(make_msg("go_ahead", "logical-events", 0))
+    strategy.submit(make_msg("do_not_go_ahead", "logical-events", 2))
+    strategy.submit(make_msg("go_ahead", "logical-events", 3))
     strategy.poll()
 
     topic = Topic("transformed-events")
@@ -87,10 +87,10 @@ def test_single_route(broker: LocalBroker[KafkaPayload], pipeline: Pipeline) -> 
     commit.assert_has_calls(
         [
             call({}),
-            call({Partition(Topic("events"), 0): 1}),
+            call({Partition(Topic("logical-events"), 0): 1}),
             call({}),
-            call({Partition(Topic("events"), 0): 3}),
+            call({Partition(Topic("logical-events"), 0): 3}),
             call({}),
-            call({Partition(Topic("events"), 0): 4}),
+            call({Partition(Topic("logical-events"), 0): 4}),
         ]
     )

--- a/sentry_streams/tests/test_pipeline.py
+++ b/sentry_streams/tests/test_pipeline.py
@@ -22,13 +22,13 @@ def pipeline() -> Pipeline:
     source = StreamSource(
         name="source",
         ctx=pipeline,
-        stream_name="logical-events",
+        stream_name="events",
     )
 
     source2 = StreamSource(
         name="source2",
         ctx=pipeline,
-        stream_name="anotehr-logical-events",
+        stream_name="anotehr-events",
     )
 
     filter = Filter(

--- a/sentry_streams/tests/test_pipeline.py
+++ b/sentry_streams/tests/test_pipeline.py
@@ -22,13 +22,13 @@ def pipeline() -> Pipeline:
     source = StreamSource(
         name="source",
         ctx=pipeline,
-        stream_name="events",
+        stream_name="logical-events",
     )
 
     source2 = StreamSource(
         name="source2",
         ctx=pipeline,
-        stream_name="anotehr-events",
+        stream_name="anotehr-logical-events",
     )
 
     filter = Filter(


### PR DESCRIPTION
Our current way of configuring topics in `runnner.py` allows topics to be aliased to different  names, but the arroyo adapter has no knowledge of the topics config and doesn't work with aliased topics.

We'll reach a decision on this in the future, but for now keep our current structure but remove all the `logical-events` aliases for the `events` topic.