### PR TITLE
Add support for multiple chains in the DSL

### DIFF
--- a/sentry_streams/sentry_streams/examples/multi_chain.py
+++ b/sentry_streams/sentry_streams/examples/multi_chain.py
@@ -1,0 +1,56 @@
+from json import JSONDecodeError, dumps, loads
+from typing import Any, Mapping, cast
+
+from sentry_streams.pipeline import Map, multi_chain, streaming_source
+
+
+def parse(msg: str) -> Mapping[str, Any]:
+    try:
+        parsed = loads(msg)
+    except JSONDecodeError:
+        return {"type": "invalid"}
+
+    return cast(Mapping[str, Any], parsed)
+
+
+def serialize(msg: Mapping[str, Any]) -> str:
+    return dumps(msg)
+
+
+def do_something(msg: Mapping[str, Any]) -> Mapping[str, Any]:
+    # Do something with the message
+    return msg
+
+
+pipeline = multi_chain(
+    [
+        # Main Ingest chain
+        streaming_source("ingest", stream_name="ingest-events")
+        .apply("parse_msg", Map(parse))
+        .apply("process", Map(do_something))
+        .apply("serialize", Map(serialize))
+        .sink("eventstream", stream_name="events"),
+        # Snuba chain to Clickhouse
+        streaming_source("snuba", stream_name="events")
+        .apply("snuba_parse_msg", Map(parse))
+        .sink(
+            "clickhouse",
+            stream_name="someewhere",
+        ),
+        # Super Big Consumer chain
+        streaming_source("sbc", stream_name="events")
+        .apply("sbc_parse_msg", Map(parse))
+        .sink(
+            "sbc_sink",
+            stream_name="someewhere",
+        ),
+        # Post process chain
+        streaming_source("post_process", stream_name="events")
+        .apply("post_parse_msg", Map(parse))
+        .apply("postprocess", Map(do_something))
+        .sink(
+            "devnull",
+            stream_name="someewhereelse",
+        ),
+    ]
+)

--- a/sentry_streams/sentry_streams/pipeline/__init__.py
+++ b/sentry_streams/sentry_streams/pipeline/__init__.py
@@ -4,6 +4,7 @@ from sentry_streams.pipeline.chain import (
     FlatMap,
     Map,
     Reducer,
+    multi_chain,
     segment,
     streaming_source,
 )
@@ -11,6 +12,7 @@ from sentry_streams.pipeline.chain import (
 __all__ = [
     "streaming_source",
     "segment",
+    "multi_chain",
     "Map",
     "Filter",
     "FlatMap",

--- a/sentry_streams/sentry_streams/pipeline/chain.py
+++ b/sentry_streams/sentry_streams/pipeline/chain.py
@@ -263,4 +263,13 @@ def streaming_source(name: str, stream_name: str) -> ExtensibleChain:
     return pipeline
 
 
-# TODO: Support pipelines with multiple sources.
+def multi_chain(chains: Sequence[Chain]) -> Pipeline:
+    """
+    Creates a pipeline that contains multiple chains, where every
+    chain is a portion of the pipeline that starts with a source
+    and ends with multiple sinks.
+    """
+    pipeline = Pipeline()
+    for chain in chains:
+        pipeline.add(chain)
+    return pipeline

--- a/sentry_streams/sentry_streams/runner.py
+++ b/sentry_streams/sentry_streams/runner.py
@@ -118,7 +118,31 @@ def main() -> None:
                 "auto_offset_reset": "latest",
                 "consumer_group": "test",
                 "additional_settings": {},
-            }
+            },
+            "ingest": {
+                "bootstrap_servers": [args.broker],
+                "auto_offset_reset": "latest",
+                "consumer_group": "test1",
+                "additional_settings": {},
+            },
+            "snuba": {
+                "bootstrap_servers": [args.broker],
+                "auto_offset_reset": "latest",
+                "consumer_group": "test2",
+                "additional_settings": {},
+            },
+            "sbc": {
+                "bootstrap_servers": [args.broker],
+                "auto_offset_reset": "latest",
+                "consumer_group": "test3",
+                "additional_settings": {},
+            },
+            "post_process": {
+                "bootstrap_servers": [args.broker],
+                "auto_offset_reset": "latest",
+                "consumer_group": "test4",
+                "additional_settings": {},
+            },
         },
         "sinks_config": {
             "kafkasink": {
@@ -130,6 +154,22 @@ def main() -> None:
                 "additional_settings": {},
             },
             "kafkasink3": {
+                "bootstrap_servers": [args.broker],
+                "additional_settings": {},
+            },
+            "eventstream": {
+                "bootstrap_servers": [args.broker],
+                "additional_settings": {},
+            },
+            "clickhouse": {
+                "bootstrap_servers": [args.broker],
+                "additional_settings": {},
+            },
+            "sbc_sink": {
+                "bootstrap_servers": [args.broker],
+                "additional_settings": {},
+            },
+            "devnull": {
                 "bootstrap_servers": [args.broker],
                 "additional_settings": {},
             },


### PR DESCRIPTION
A streaming pipeline can cinlude multiple Chains each of which
starts with a different consumer.
This is how we can manage pipelines that have intermediate topics.

This supports the creation of a pipeline with the DSL when there
are multiple sources.

See the example for details on how it works
