### PR TITLE
feat: add explicit Broadcast step to pipeline graph

### DIFF
--- a/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
@@ -36,6 +36,7 @@ from sentry_streams.pipeline.function_template import (
     OutputType,
 )
 from sentry_streams.pipeline.pipeline import (
+    Broadcast,
     Filter,
     FlatMap,
     Map,
@@ -220,6 +221,16 @@ class ArroyoAdapter(StreamAdapter[Route, Route]):
     ) -> Route:
         """
         Build a reduce operator for the platform the adapter supports.
+        """
+        raise NotImplementedError
+
+    def broadcast(
+        self,
+        step: Broadcast,
+        stream: Route,
+    ) -> Mapping[str, Route]:
+        """
+        Build a broadcast operator for the platform the adapter supports.
         """
         raise NotImplementedError
 

--- a/sentry_streams/sentry_streams/adapters/stream_adapter.py
+++ b/sentry_streams/sentry_streams/adapters/stream_adapter.py
@@ -125,7 +125,7 @@ class StreamAdapter(ABC, Generic[StreamT, StreamSinkT]):
         self,
         step: Broadcast,
         stream: StreamT,
-    ) -> StreamT:
+    ) -> Mapping[str, StreamT]:
         """
         Build a broadcast operator for the platform the adapter supports.
         """
@@ -194,7 +194,7 @@ class RuntimeTranslator(Generic[StreamT, StreamSinkT]):
 
         elif step_type is StepType.BROADCAST:
             assert isinstance(step, Broadcast) and stream is not None
-            return {step_name: self.adapter.broadcast(step, stream)}
+            return self.adapter.broadcast(step, stream)
 
         else:
             assert_never(step_type)

--- a/sentry_streams/sentry_streams/examples/blq.py
+++ b/sentry_streams/sentry_streams/examples/blq.py
@@ -13,7 +13,7 @@ storage_branch = (
         "Send message to DBs",
         routes=[
             segment("sbc").sink("kafkasink", stream_name="transformed-events"),
-            segment("clickhouse").sink("kafkasink2", stream_name="transformed-events2"),
+            segment("clickhouse").sink("kafkasink2", stream_name="transformed-events-2"),
         ],
     )
 )

--- a/sentry_streams/sentry_streams/pipeline/chain.py
+++ b/sentry_streams/sentry_streams/pipeline/chain.py
@@ -161,7 +161,7 @@ class ExtensibleChain(Chain):
             routes={
                 Routes.ROUTE1: segment(name="route1") # Creates a branch
                 .apply("transform2", Map(lambda msg: msg))
-                .sink("myoutput1", "transformed-events2"),
+                .sink("myoutput1", "transformed-events-2"),
                 Routes.ROUTE2: segment(name="route2")
                 .apply("transform3", Map(lambda msg: msg))
                 .sink("myoutput2", "transformed-events3"),
@@ -203,9 +203,10 @@ class ExtensibleChain(Chain):
             name,
             ctx=self,
             inputs=[self.__edge],
+            routes=[Branch(name=chain.name, ctx=self) for chain in routes],
         )
         for chain in routes:
-            self.merge(other=chain, merge_point=self.__edge.name)
+            self.merge(other=chain, merge_point=chain.name)
         return self
 
     def route(

--- a/sentry_streams/sentry_streams/pipeline/chain.py
+++ b/sentry_streams/sentry_streams/pipeline/chain.py
@@ -25,6 +25,7 @@ from sentry_streams.pipeline.pipeline import (
 from sentry_streams.pipeline.pipeline import Batch as BatchStep
 from sentry_streams.pipeline.pipeline import (
     Branch,
+    Broadcast,
 )
 from sentry_streams.pipeline.pipeline import Filter as FilterStep
 from sentry_streams.pipeline.pipeline import FlatMap as FlatMapStep
@@ -198,6 +199,11 @@ class ExtensibleChain(Chain):
         Forks the pipeline sending all messages to all routes.
         """
         assert self.__edge is not None
+        Broadcast(
+            name,
+            ctx=self,
+            inputs=[self.__edge],
+        )
         for chain in routes:
             self.merge(other=chain, merge_point=self.__edge.name)
         return self

--- a/sentry_streams/sentry_streams/pipeline/pipeline.py
+++ b/sentry_streams/sentry_streams/pipeline/pipeline.py
@@ -307,7 +307,13 @@ class Broadcast(WithInput):
     A Broadcast step will forward messages to all downstream branches in a pipeline.
     """
 
+    routes: Sequence[Branch]
     step_type: StepType = StepType.BROADCAST
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        for branch_step in self.routes:
+            self.ctx.register_edge(self, branch_step)
 
 
 class Reduce(WithInput, ABC, Generic[MeasurementUnit, InputType, OutputType]):

--- a/sentry_streams/sentry_streams/pipeline/pipeline.py
+++ b/sentry_streams/sentry_streams/pipeline/pipeline.py
@@ -33,6 +33,7 @@ from sentry_streams.pipeline.window import MeasurementUnit, TumblingWindow, Wind
 
 class StepType(Enum):
     BRANCH = "branch"
+    BROADCAST = "broadcast"
     FILTER = "filter"
     FLAT_MAP = "flat_map"
     MAP = "map"
@@ -298,6 +299,15 @@ class Router(WithInput, Generic[RoutingFuncReturnType]):
         super().__post_init__()
         for branch_step in self.routing_table.values():
             self.ctx.register_edge(self, branch_step)
+
+
+@dataclass
+class Broadcast(WithInput):
+    """
+    A Broadcast step will forward messages to all downstream branches in a pipeline.
+    """
+
+    step_type: StepType = StepType.BROADCAST
 
 
 class Reduce(WithInput, ABC, Generic[MeasurementUnit, InputType, OutputType]):

--- a/sentry_streams/sentry_streams/runner.py
+++ b/sentry_streams/sentry_streams/runner.py
@@ -24,9 +24,6 @@ def iterate_edges(p_graph: Pipeline, translator: RuntimeTranslator[StreamT, Stre
     It currently has the structure to deal with, but has no
     real support for, fan-in streams
     """
-    from pprint import pprint
-
-    pprint(p_graph.__dict__)
 
     step_streams = {}
 
@@ -37,7 +34,6 @@ def iterate_edges(p_graph: Pipeline, translator: RuntimeTranslator[StreamT, Stre
             step_streams[source_name] = source_streams[source_name]
 
         while step_streams:
-            logger.info(f"{step_streams=}")
             for input_name in list(step_streams):
                 output_steps = p_graph.outgoing_edges[input_name]
                 input_stream = step_streams.pop(input_name)
@@ -50,7 +46,6 @@ def iterate_edges(p_graph: Pipeline, translator: RuntimeTranslator[StreamT, Stre
                     logger.info(f"Apply step: {next_step.name}")
                     # TODO: Make the typing align with the streams being iterated through. Reconsider algorithm as needed.
                     next_step_stream = translator.translate_step(next_step, input_stream)  # type: ignore
-                    logger.info(f"{next_step_stream=}")
                     for branch_name in next_step_stream:
                         step_streams[branch_name] = next_step_stream[branch_name]
 

--- a/sentry_streams/sentry_streams/runner.py
+++ b/sentry_streams/sentry_streams/runner.py
@@ -24,6 +24,9 @@ def iterate_edges(p_graph: Pipeline, translator: RuntimeTranslator[StreamT, Stre
     It currently has the structure to deal with, but has no
     real support for, fan-in streams
     """
+    from pprint import pprint
+
+    pprint(p_graph.__dict__)
 
     step_streams = {}
 
@@ -34,6 +37,7 @@ def iterate_edges(p_graph: Pipeline, translator: RuntimeTranslator[StreamT, Stre
             step_streams[source_name] = source_streams[source_name]
 
         while step_streams:
+            logger.info(f"{step_streams=}")
             for input_name in list(step_streams):
                 output_steps = p_graph.outgoing_edges[input_name]
                 input_stream = step_streams.pop(input_name)
@@ -46,6 +50,7 @@ def iterate_edges(p_graph: Pipeline, translator: RuntimeTranslator[StreamT, Stre
                     logger.info(f"Apply step: {next_step.name}")
                     # TODO: Make the typing align with the streams being iterated through. Reconsider algorithm as needed.
                     next_step_stream = translator.translate_step(next_step, input_stream)  # type: ignore
+                    logger.info(f"{next_step_stream=}")
                     for branch_name in next_step_stream:
                         step_streams[branch_name] = next_step_stream[branch_name]
 


### PR DESCRIPTION
Broadcast in flink doesn't require any processing as it works implicitly by just plugging a step into the `inputs` of mutliple downstream steps.
Broadcast in arroyo will need to do actual work on the adapter side, so we'll need an explicit `Broadcast()` step for that to work properly. This PR adds that step to the pipeline graph.
The `Broadcast()` step also has a routes list in the form of a list of `Branch()` much like the router step does.