### PR TITLE
ref: Make Flink tests also use deployment config

### DIFF
--- a/sentry_streams/pyproject.toml
+++ b/sentry_streams/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
 ]
 
 [tool.setuptools.package-data]
-sentry_streams = ["py.typed", "config.json"]
+sentry_streams = ["py.typed", "config.json", "deployment_config/test_flink_config.yaml"]
 
 [tool.pytest.ini_options]
 minversion = "0.0.15"

--- a/sentry_streams/sentry_streams/deployment_config/test_flink_config.yaml
+++ b/sentry_streams/sentry_streams/deployment_config/test_flink_config.yaml
@@ -1,0 +1,21 @@
+env:
+  parallelism: 2
+
+pipeline:
+  segments:
+    - steps_config:
+        myinput:
+          starts_segment: True
+          bootstrap_servers: "localhost:9092"
+
+        kafkasink:
+          bootstrap_servers: "localhost:9092"
+
+        kafkasink_1:
+          bootstrap_servers: "localhost:9092"
+
+        kafkasink2:
+          bootstrap_servers: "localhost:9092"
+
+        kafkasink_2:
+          bootstrap_servers: "localhost:9092"

--- a/sentry_streams/sentry_streams/runner.py
+++ b/sentry_streams/sentry_streams/runner.py
@@ -116,7 +116,6 @@ def main() -> None:
 
     with open(args.config, "r") as config_file:
         environment_config = yaml.safe_load(config_file)
-        logger.info(environment_config)
 
     config_template = importlib.resources.files("sentry_streams") / "config.json"
     with config_template.open("r") as file:


### PR DESCRIPTION
Small change so we can remove any hardcoded configurations from tests