### PR TITLE
fix: arroyo adapter deployment config

### DIFF
--- a/sentry_streams/docs/source/intro.rst
+++ b/sentry_streams/docs/source/intro.rst
@@ -102,9 +102,9 @@ and produces the result to another topic.
 
 .. code-block::
 
-    python -m sentry_streams.runner \
+    SEGMENT_ID=0 python -m sentry_streams.runner \
     -n Batch \
-    --broker localhost:9092 \
+    --config sentry_streams/deployment_config/<YOUR CONFIG FILE>.yaml \
     --adapter arroyo \
     <YOUR PIPELINE FILE>
 

--- a/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
@@ -95,7 +95,7 @@ class StreamSources:
             self.__sources[source_name] = KafkaConsumer(
                 build_kafka_consumer_configuration(
                     default_config=source_config.get("additional_settings", {}),
-                    bootstrap_servers=source_config.get("bootstrap_servers", "localhost: 9092"),
+                    bootstrap_servers=source_config.get("bootstrap_servers", ["localhost: 9092"]),
                     auto_offset_reset=(source_config.get("auto_offset_reset", "latest")),
                     group_id=f"pipeline-{source_name}",
                 )

--- a/sentry_streams/sentry_streams/deployment_config/blq_config.yaml
+++ b/sentry_streams/sentry_streams/deployment_config/blq_config.yaml
@@ -1,0 +1,34 @@
+# Config file for examples/blq.py
+env: {}
+
+pipeline:
+  segments:
+    - steps_config:
+        ingest:
+          starts_segment: True
+          bootstrap_servers:
+            - "localhost:9092"
+        unpack_message:
+          bootstrap_servers:
+            - "localhost:9092"
+        blq_router:
+          bootstrap_servers:
+            - "localhost:9092"
+        dump_msg_delayed:
+          bootstrap_servers:
+            - "localhost:9092"
+        dump_msg_recent:
+          bootstrap_servers:
+            - "localhost:9092"
+        send_message_to_DBs:
+          bootstrap_servers:
+            - "localhost:9092"
+        kafkasink:
+          bootstrap_servers:
+            - "localhost:9092"
+        kafkasink2:
+          bootstrap_servers:
+            - "localhost:9092"
+        kafkasink3:
+          bootstrap_servers:
+            - "localhost:9092"

--- a/sentry_streams/sentry_streams/deployment_config/test_flink_config.yaml
+++ b/sentry_streams/sentry_streams/deployment_config/test_flink_config.yaml
@@ -6,16 +6,21 @@ pipeline:
     - steps_config:
         myinput:
           starts_segment: True
-          bootstrap_servers: "localhost:9092"
+          bootstrap_servers:
+            - "localhost:9092"
 
         kafkasink:
-          bootstrap_servers: "localhost:9092"
+          bootstrap_servers:
+            - "localhost:9092"
 
         kafkasink_1:
-          bootstrap_servers: "localhost:9092"
+          bootstrap_servers:
+            - "localhost:9092"
 
         kafkasink2:
-          bootstrap_servers: "localhost:9092"
+          bootstrap_servers:
+            - "localhost:9092"
 
         kafkasink_2:
-          bootstrap_servers: "localhost:9092"
+          bootstrap_servers:
+            - "localhost:9092"

--- a/sentry_streams/sentry_streams/deployment_config/transformer_config.yaml
+++ b/sentry_streams/sentry_streams/deployment_config/transformer_config.yaml
@@ -8,7 +8,9 @@ pipeline:
     - steps_config:
         myinput:
           starts_segment: True
-          bootstrap_servers: "localhost:9092"
+          bootstrap_servers:
+            - "localhost:9092"
 
         kafkasink2:
-          bootstrap_servers: "localhost:9092"
+          bootstrap_servers:
+            - "localhost:9092"

--- a/sentry_streams/sentry_streams/examples/blq.py
+++ b/sentry_streams/sentry_streams/examples/blq.py
@@ -10,7 +10,7 @@ storage_branch = (
     segment(name="recent")
     .apply("dump_msg_recent", Map(json_dump_message))
     .broadcast(
-        "Send message to DBs",
+        "send_message_to_DBs",
         routes=[
             segment("sbc").sink("kafkasink", stream_name="transformed-events"),
             segment("clickhouse").sink("kafkasink2", stream_name="transformed-events-2"),

--- a/sentry_streams/uv.lock
+++ b/sentry_streams/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.11"
 
 [[package]]
@@ -565,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "sentry-streams"
-version = "0.0.14"
+version = "0.0.16"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
The arroyo adapter didn't work with the new deployment config, this PR should fix.
Also includes config file for `blq.py` example.

The `flink_deploy` script will also need to be updated for the deployment config to work on local dockerized flink, that will come in a future PR.