### PR TITLE
ref: Type out chains and steps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,8 @@ repos:
           responses,
           "sentry-arroyo>=2.18.2",
           types-pyYAML,
-          types-jsonschema
+          types-jsonschema,
+          "sentry-kafka-schemas>=1.2.0",
         ]
         files: ^sentry_streams/.+
   - repo: https://github.com/pycqa/isort

--- a/sentry_streams/pyproject.toml
+++ b/sentry_streams/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "sentry-arroyo>=2.18.2",
     "pyyaml>=6.0.2",
     "jsonschema>=4.23.0",
+    "sentry-kafka-schemas>=1.2.0",
 ]
 
 [dependency-groups]

--- a/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
@@ -149,13 +149,12 @@ class ArroyoAdapter(StreamAdapter[Route, Route]):
         source_name = step.name
         self.__sources.add_source(step)
 
-        filter = None
-        if hasattr(step, "header_filter") and step.header_filter:
-            filter = step.header_filter
+        # This is the Arroyo adapter, and it only supports consuming from StreamSource anyways
+        assert isinstance(step, StreamSource)
 
-        assert hasattr(step, "stream_name")
-
-        self.__consumers[source_name] = ArroyoConsumer(source_name, step.stream_name, filter)
+        self.__consumers[source_name] = ArroyoConsumer(
+            source_name, step.stream_name, step.header_filter
+        )
 
         return Route(source_name, [])
 

--- a/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
@@ -17,6 +17,8 @@ from arroyo.backends.kafka.configuration import (
 from arroyo.backends.kafka.consumer import KafkaConsumer, KafkaPayload, KafkaProducer
 from arroyo.processing.processor import StreamProcessor
 from arroyo.types import Topic
+from sentry_kafka_schemas import get_codec
+from sentry_kafka_schemas.codecs import Codec
 
 from sentry_streams.adapters.arroyo.consumer import (
     ArroyoConsumer,
@@ -151,9 +153,13 @@ class ArroyoAdapter(StreamAdapter[Route, Route]):
 
         # This is the Arroyo adapter, and it only supports consuming from StreamSource anyways
         assert isinstance(step, StreamSource)
+        try:
+            schema: Codec[Any] = get_codec(step.stream_name)
+        except Exception:
+            raise ValueError(f"Kafka topic {step.stream_name} has no associated schema")
 
         self.__consumers[source_name] = ArroyoConsumer(
-            source_name, step.stream_name, step.header_filter
+            source_name, step.stream_name, schema, step.header_filter
         )
 
         return Route(source_name, [])

--- a/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
@@ -148,7 +148,12 @@ class ArroyoAdapter(StreamAdapter[Route, Route]):
         """
         source_name = step.name
         self.__sources.add_source(step)
-        self.__consumers[source_name] = ArroyoConsumer(source_name)
+
+        filter = None
+        if hasattr(step, "header_filter") and step.header_filter:
+            filter = step.header_filter
+
+        self.__consumers[source_name] = ArroyoConsumer(source_name, filter)
 
         return Route(source_name, [])
 

--- a/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
@@ -153,7 +153,9 @@ class ArroyoAdapter(StreamAdapter[Route, Route]):
         if hasattr(step, "header_filter") and step.header_filter:
             filter = step.header_filter
 
-        self.__consumers[source_name] = ArroyoConsumer(source_name, filter)
+        assert hasattr(step, "stream_name")
+
+        self.__consumers[source_name] = ArroyoConsumer(source_name, step.stream_name, filter)
 
         return Route(source_name, [])
 

--- a/sentry_streams/sentry_streams/adapters/arroyo/consumer.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/consumer.py
@@ -10,9 +10,12 @@ from arroyo.processing.strategies.abstract import (
 )
 from arroyo.processing.strategies.run_task import RunTask
 from arroyo.types import Commit, FilteredPayload, Message, Partition
+from sentry_kafka_schemas import get_codec
+from sentry_kafka_schemas.codecs import Codec
 
 from sentry_streams.adapters.arroyo.routes import Route, RoutedValue
 from sentry_streams.adapters.arroyo.steps import ArroyoStep
+from sentry_streams.pipeline.chain import Message as StreamsMessage
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +70,11 @@ class ArroyoConsumer:
 
             if not filtered:
                 value = message.payload.value
-                return RoutedValue(route=Route(source=self.source, waypoints=[]), payload=value)
+                schema: Codec[Any] = get_codec(self.source)
+                return RoutedValue(
+                    route=Route(source=self.source, waypoints=[]),
+                    payload=StreamsMessage(schema=schema, payload=value),
+                )
             else:
                 return FilteredPayload()
 

--- a/sentry_streams/sentry_streams/adapters/arroyo/consumer.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/consumer.py
@@ -69,7 +69,11 @@ class ArroyoConsumer:
 
             if not filtered:
                 value = message.payload.value
-                schema: Codec[Any] = get_codec(self.stream_name)
+                try:
+                    schema: Codec[Any] = get_codec(self.stream_name)
+                except Exception:
+                    raise ValueError(f"Kafka topic {self.stream_name} has no associated schema")
+
                 return RoutedValue(
                     route=Route(source=self.source, waypoints=[]),
                     payload=StreamsMessage(schema=schema, payload=value),

--- a/sentry_streams/sentry_streams/adapters/arroyo/consumer.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/consumer.py
@@ -67,7 +67,9 @@ class ArroyoConsumer:
                 if self.header_filter not in headers:
                     filtered = True
 
-            if not filtered:
+            if filtered:
+                return FilteredPayload()
+            else:
                 value = message.payload.value
                 try:
                     schema: Codec[Any] = get_codec(self.stream_name)
@@ -78,8 +80,6 @@ class ArroyoConsumer:
                     route=Route(source=self.source, waypoints=[]),
                     payload=StreamsMessage(schema=schema, payload=value),
                 )
-            else:
-                return FilteredPayload()
 
         strategy: ProcessingStrategy[Any] = CommitOffsets(commit)
         for step in reversed(self.steps):

--- a/sentry_streams/sentry_streams/adapters/arroyo/forwarder.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/forwarder.py
@@ -28,7 +28,10 @@ class Forwarder(ProcessingStrategy[Union[FilteredPayload, RoutedValue]]):
     def submit(self, message: Message[Union[FilteredPayload, RoutedValue]]) -> None:
         message_payload = message.value.payload
         if isinstance(message_payload, RoutedValue) and message_payload.route == self.__route:
-            kafka_payload = message.value.replace(KafkaPayload(None, message_payload.payload, []))
+            # TODO: get headers from the StreamsMessage
+            kafka_payload = message.value.replace(
+                KafkaPayload(None, message_payload.payload.payload, [])
+            )
             self.__produce_step.submit(Message(kafka_payload))
         else:
             self.__next_step.submit(message)

--- a/sentry_streams/sentry_streams/adapters/arroyo/forwarder.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/forwarder.py
@@ -28,9 +28,7 @@ class Forwarder(ProcessingStrategy[Union[FilteredPayload, RoutedValue]]):
     def submit(self, message: Message[Union[FilteredPayload, RoutedValue]]) -> None:
         message_payload = message.value.payload
         if isinstance(message_payload, RoutedValue) and message_payload.route == self.__route:
-            kafka_payload = message.value.replace(
-                KafkaPayload(None, str(message_payload.payload).encode("utf-8"), [])
-            )
+            kafka_payload = message.value.replace(KafkaPayload(None, message_payload.payload, []))
             self.__produce_step.submit(Message(kafka_payload))
         else:
             self.__next_step.submit(message)

--- a/sentry_streams/sentry_streams/adapters/arroyo/forwarder.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/forwarder.py
@@ -29,6 +29,7 @@ class Forwarder(ProcessingStrategy[Union[FilteredPayload, RoutedValue]]):
         message_payload = message.value.payload
         if isinstance(message_payload, RoutedValue) and message_payload.route == self.__route:
             # TODO: get headers from the StreamsMessage
+            assert isinstance(message_payload.payload.payload, bytes)
             kafka_payload = message.value.replace(
                 KafkaPayload(None, message_payload.payload.payload, [])
             )

--- a/sentry_streams/sentry_streams/adapters/arroyo/msg_wrapper.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/msg_wrapper.py
@@ -1,0 +1,51 @@
+import time
+from typing import Optional, TypeVar, Union, cast
+
+from arroyo.processing.strategies.abstract import ProcessingStrategy
+from arroyo.types import FilteredPayload, Message, Value
+
+from sentry_streams.adapters.arroyo.routes import Route, RoutedValue
+from sentry_streams.pipeline.message import Message as StreamsMessage
+
+TPayload = TypeVar("TPayload")
+
+
+class MessageWrapper(ProcessingStrategy[Union[FilteredPayload, TPayload]]):
+    """
+    Custom processing strategy which either produces an incoming message via a given Producer
+    if the Route of the message matches this strategy's Route, or forwards the message
+    to the next strategy provided.
+    """
+
+    def __init__(
+        self,
+        route: Route,
+        next_step: ProcessingStrategy[Union[FilteredPayload, RoutedValue]],
+    ) -> None:
+        self.__next_step = next_step
+        self.__route = route
+
+    def submit(self, message: Message[Union[FilteredPayload, TPayload]]) -> None:
+        now = time.time()
+        if not isinstance(message.payload, FilteredPayload):
+            msg = StreamsMessage(message.payload, [], now, None)
+
+            routed_msg: Message[RoutedValue] = Message(
+                Value(committable=message.value.committable, payload=RoutedValue(self.__route, msg))
+            )
+            self.__next_step.submit(routed_msg)
+
+        else:
+            self.__next_step.submit(cast(Message[FilteredPayload], message))
+
+    def poll(self) -> None:
+        self.__next_step.poll()
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        self.__next_step.join(timeout)
+
+    def close(self) -> None:
+        self.__next_step.close()
+
+    def terminate(self) -> None:
+        self.__next_step.terminate()

--- a/sentry_streams/sentry_streams/adapters/arroyo/reduce.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/reduce.py
@@ -281,6 +281,8 @@ def build_arroyo_windowed_reduce(
 
             arroyo_acc = ArroyoAccumulator(accumulator)
 
+            logger.info(f"INITIAL VALUE {arroyo_acc.initial_value().payload}")
+
             match window_size:
                 case int():
                     return Reduce(

--- a/sentry_streams/sentry_streams/adapters/arroyo/reduce.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/reduce.py
@@ -135,7 +135,7 @@ class TimeWindowedReduce(
         self.window_size = int(window_size)
         self.window_slide = int(window_slide)
 
-        self.next_step = next_step
+        self.msg_wrap_step = next_step
         self.start_time = time.time()
         self.route = route
 
@@ -180,9 +180,7 @@ class TimeWindowedReduce(
 
         # If there is a gap in the data, it is possible to have empty flushes
         if payload:
-            # construct a StreamsMessage
-            # result = RoutedValue(self.route, payload)
-            self.next_step.submit(
+            self.msg_wrap_step.submit(
                 Message(Value(cast(TResult, payload), merged_window.get_offsets()))
             )
 
@@ -207,12 +205,12 @@ class TimeWindowedReduce(
     def submit(self, message: Message[Union[FilteredPayload, TPayload]]) -> None:
         value = message.payload
         if isinstance(value, FilteredPayload):
-            self.next_step.submit(cast(Message[TResult], message))
+            self.msg_wrap_step.submit(cast(Message[Union[FilteredPayload, TResult]], message))
             return
 
         assert isinstance(value, RoutedValue)
         if value.route != self.route:
-            self.next_step.submit(cast(Message[TResult], message))
+            self.msg_wrap_step.submit(cast(Message[Union[FilteredPayload, TResult]], message))
             return
 
         cur_time = time.time() - self.start_time
@@ -226,23 +224,23 @@ class TimeWindowedReduce(
         cur_time = time.time() - self.start_time
         self.__maybe_flush(cur_time)
 
-        self.next_step.poll()
+        self.msg_wrap_step.poll()
 
     def close(self) -> None:
-        self.next_step.close()
+        self.msg_wrap_step.close()
 
     def terminate(self) -> None:
-        self.next_step.terminate()
+        self.msg_wrap_step.terminate()
 
     def join(self, timeout: Optional[float] = None) -> None:
-        self.next_step.close()
-        self.next_step.join()
+        self.msg_wrap_step.close()
+        self.msg_wrap_step.join()
 
 
 def build_arroyo_windowed_reduce(
     streams_window: Window[MeasurementUnit],
     accumulator: Callable[[], Accumulator[Any, Any]],
-    next_step: ProcessingStrategy[Union[FilteredPayload, TPayload]],
+    msg_wrapper: ProcessingStrategy[Union[FilteredPayload, TPayload]],
     route: Route,
 ) -> ProcessingStrategy[Union[FilteredPayload, TPayload]]:
 
@@ -269,7 +267,7 @@ def build_arroyo_windowed_reduce(
                         size,
                         slide,
                         accumulator,
-                        next_step,
+                        msg_wrapper,
                         route,
                     )
 
@@ -295,7 +293,7 @@ def build_arroyo_windowed_reduce(
                             arroyo_acc.accumulator,
                         ),
                         arroyo_acc.initial_value,
-                        next_step,
+                        msg_wrapper,
                     )
 
                 case timedelta():
@@ -303,7 +301,7 @@ def build_arroyo_windowed_reduce(
                         window_size.total_seconds(),
                         window_size.total_seconds(),
                         accumulator,
-                        next_step,
+                        msg_wrapper,
                         route,
                     )
 

--- a/sentry_streams/sentry_streams/adapters/arroyo/reduce.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/reduce.py
@@ -127,7 +127,7 @@ class TimeWindowedReduce(
         window_size: float,
         window_slide: float,
         acc: Callable[[], Accumulator[Any, Any]],
-        next_step: ProcessingStrategy[TResult],
+        next_step: ProcessingStrategy[Union[FilteredPayload, TResult]],
         route: Route,
     ) -> None:
 
@@ -180,9 +180,10 @@ class TimeWindowedReduce(
 
         # If there is a gap in the data, it is possible to have empty flushes
         if payload:
-            result = RoutedValue(self.route, payload)
+            # construct a StreamsMessage
+            # result = RoutedValue(self.route, payload)
             self.next_step.submit(
-                Message(Value(cast(TResult, result), merged_window.get_offsets()))
+                Message(Value(cast(TResult, payload), merged_window.get_offsets()))
             )
 
         # Refresh only the accumulator that was the first

--- a/sentry_streams/sentry_streams/adapters/arroyo/reduce.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/reduce.py
@@ -90,7 +90,7 @@ class KafkaAccumulator:
                 self.offsets[partition] = max(offsets[partition], self.offsets[partition])
 
             else:
-                self.offsets.update(offsets)
+                self.offsets[partition] = offsets[partition]
 
         return self
 

--- a/sentry_streams/sentry_streams/adapters/arroyo/reduce.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/reduce.py
@@ -281,8 +281,6 @@ def build_arroyo_windowed_reduce(
 
             arroyo_acc = ArroyoAccumulator(accumulator)
 
-            logger.info(f"INITIAL VALUE {arroyo_acc.initial_value().payload}")
-
             match window_size:
                 case int():
                     return Reduce(

--- a/sentry_streams/sentry_streams/adapters/arroyo/routes.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/routes.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import Any, MutableSequence
 
+from sentry_streams.pipeline.message import Message as StreamsMessage
+
 
 @dataclass(frozen=True)
 class Route:
@@ -23,4 +25,4 @@ class Route:
 @dataclass(frozen=True)
 class RoutedValue:
     route: Route
-    payload: Any
+    payload: StreamsMessage[Any]

--- a/sentry_streams/sentry_streams/adapters/arroyo/steps.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/steps.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Callable, Generic, TypeVar, Union
@@ -105,7 +104,7 @@ class MapStep(ArroyoStep):
                     payload=StreamsMessage(
                         self.pipeline_step.resolved_function(routed_value.payload),
                         routed_value.payload.headers,
-                        time.time(),
+                        routed_value.payload.timestamp,
                         routed_value.payload.schema,
                     ),
                 ),
@@ -140,9 +139,9 @@ class FilterStep(ArroyoStep):
                     RoutedValue(
                         self.route,
                         StreamsMessage(
-                            routed_value.payload,
+                            routed_value.payload.payload,
                             routed_value.payload.headers,
-                            time.time(),
+                            routed_value.payload.timestamp,
                             routed_value.payload.schema,
                         ),
                     )
@@ -204,7 +203,7 @@ class RouterStep(ArroyoStep, Generic[RoutingFuncReturnType]):
 
             streams_msg = payload.payload
             msg = StreamsMessage(
-                streams_msg.payload, streams_msg.headers, time.time(), streams_msg.schema
+                streams_msg.payload, streams_msg.headers, streams_msg.timestamp, streams_msg.schema
             )
 
             return RoutedValue(payload.route, msg)

--- a/sentry_streams/sentry_streams/examples/batching.py
+++ b/sentry_streams/sentry_streams/examples/batching.py
@@ -1,32 +1,33 @@
-import json
+from typing import Callable, MutableSequence, Union, cast
 
-from sentry_streams.pipeline import Batch, FlatMap, Map, streaming_source
+from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
+
+from sentry_streams.pipeline import Batch, FlatMap, streaming_source
 from sentry_streams.pipeline.batch import unbatch
-from sentry_streams.pipeline.function_template import InputType
+from sentry_streams.pipeline.chain import Parser, Serializer
+from sentry_streams.pipeline.message import Message
+from sentry_streams.pipeline.msg_parser import json_parser, json_serializer
 
-
-def build_batch_str(batch: list[InputType]) -> str:
-    d = {"batch": batch}
-
-    return json.dumps(d)
-
-
-def build_message_str(message: str) -> str:
-    d = {"message": message}
-
-    return json.dumps(d)
-
-
-pipeline = (
-    streaming_source(
-        name="myinput",
-        stream_name="events",
-    )
-    .apply("mybatch", Batch(batch_size=5))  # User simply provides the batch size
-    .apply("myunbatch", FlatMap(function=unbatch))
-    .apply("mymap", Map(function=build_message_str))
-    .sink(
-        "kafkasink",
-        stream_name="transformed-events",
-    )  # flush the batches to the Sink
+pipeline = streaming_source(
+    name="myinput",
+    stream_name="ingest-metrics",
 )
+
+# TODO: Figure out why the concrete type of InputType is not showing up in the type hint of chain1
+chain1 = pipeline.apply("parser", Parser(msg_type=IngestMetric, deserializer=json_parser)).apply(
+    "mybatch", Batch(batch_size=5)
+)  # User simply provides the batch size
+
+chain2 = chain1.apply(
+    "myunbatch",
+    FlatMap(
+        function=cast(
+            Union[Callable[[Message[MutableSequence[IngestMetric]]], Message[IngestMetric]], str],
+            unbatch,
+        )
+    ),
+)
+
+chain3 = chain2.apply("serializer", Serializer(serializer=json_serializer)).sink(
+    "kafkasink2", stream_name="transformed-events"
+)  # flush the batches to the Sink

--- a/sentry_streams/sentry_streams/examples/batching.py
+++ b/sentry_streams/sentry_streams/examples/batching.py
@@ -6,7 +6,7 @@ from sentry_streams.pipeline import Batch, FlatMap, streaming_source
 from sentry_streams.pipeline.batch import unbatch
 from sentry_streams.pipeline.chain import Parser, Serializer
 from sentry_streams.pipeline.message import Message
-from sentry_streams.pipeline.msg_parser import json_parser, json_serializer
+from sentry_streams.pipeline.msg_parser import msg_parser, msg_serializer
 
 pipeline = streaming_source(
     name="myinput",
@@ -14,7 +14,7 @@ pipeline = streaming_source(
 )
 
 # TODO: Figure out why the concrete type of InputType is not showing up in the type hint of chain1
-chain1 = pipeline.apply("parser", Parser(msg_type=IngestMetric, deserializer=json_parser)).apply(
+chain1 = pipeline.apply("parser", Parser(msg_type=IngestMetric, deserializer=msg_parser)).apply(
     "mybatch", Batch(batch_size=5)
 )  # User simply provides the batch size
 
@@ -28,6 +28,6 @@ chain2 = chain1.apply(
     ),
 )
 
-chain3 = chain2.apply("serializer", Serializer(serializer=json_serializer)).sink(
+chain3 = chain2.apply("serializer", Serializer(serializer=msg_serializer)).sink(
     "kafkasink2", stream_name="transformed-events"
 )  # flush the batches to the Sink

--- a/sentry_streams/sentry_streams/examples/batching.py
+++ b/sentry_streams/sentry_streams/examples/batching.py
@@ -1,11 +1,8 @@
-from typing import Callable, MutableSequence, Union, cast
-
 from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 
 from sentry_streams.pipeline import Batch, FlatMap, streaming_source
 from sentry_streams.pipeline.batch import unbatch
 from sentry_streams.pipeline.chain import Parser, Serializer
-from sentry_streams.pipeline.message import Message
 
 pipeline = streaming_source(
     name="myinput",
@@ -19,12 +16,7 @@ chain1 = pipeline.apply("parser", Parser(msg_type=IngestMetric)).apply(
 
 chain2 = chain1.apply(
     "myunbatch",
-    FlatMap(
-        function=cast(
-            Union[Callable[[Message[MutableSequence[IngestMetric]]], Message[IngestMetric]], str],
-            unbatch,
-        )
-    ),
+    FlatMap(function=unbatch),
 )
 
 chain3 = chain2.apply("serializer", Serializer()).sink(

--- a/sentry_streams/sentry_streams/examples/batching.py
+++ b/sentry_streams/sentry_streams/examples/batching.py
@@ -6,7 +6,6 @@ from sentry_streams.pipeline import Batch, FlatMap, streaming_source
 from sentry_streams.pipeline.batch import unbatch
 from sentry_streams.pipeline.chain import Parser, Serializer
 from sentry_streams.pipeline.message import Message
-from sentry_streams.pipeline.msg_parser import msg_parser, msg_serializer
 
 pipeline = streaming_source(
     name="myinput",
@@ -14,7 +13,7 @@ pipeline = streaming_source(
 )
 
 # TODO: Figure out why the concrete type of InputType is not showing up in the type hint of chain1
-chain1 = pipeline.apply("parser", Parser(msg_type=IngestMetric, deserializer=msg_parser)).apply(
+chain1 = pipeline.apply("parser", Parser(msg_type=IngestMetric)).apply(
     "mybatch", Batch(batch_size=5)
 )  # User simply provides the batch size
 
@@ -28,6 +27,6 @@ chain2 = chain1.apply(
     ),
 )
 
-chain3 = chain2.apply("serializer", Serializer(serializer=msg_serializer)).sink(
+chain3 = chain2.apply("serializer", Serializer()).sink(
     "kafkasink2", stream_name="transformed-events"
 )  # flush the batches to the Sink

--- a/sentry_streams/sentry_streams/examples/blq.py
+++ b/sentry_streams/sentry_streams/examples/blq.py
@@ -1,26 +1,32 @@
+from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
+
 from sentry_streams.examples.blq_fn import (
     DownstreamBranch,
-    json_dump_message,
     should_send_to_blq,
-    unpack_kafka_message,
 )
-from sentry_streams.pipeline import Map, segment, streaming_source
+from sentry_streams.pipeline import segment, streaming_source
+from sentry_streams.pipeline.chain import Parser, Serializer
+from sentry_streams.pipeline.msg_parser import json_parser, json_serializer
 
 storage_branch = (
-    segment(name="recent")
-    .apply("dump_msg_recent", Map(json_dump_message))
+    segment(name="recent", msg_type=IngestMetric)
+    .apply("serializer1", Serializer(serializer=json_serializer))
     .broadcast(
         "send_message_to_DBs",
         routes=[
-            segment("sbc").sink("kafkasink", stream_name="transformed-events"),
-            segment("clickhouse").sink("kafkasink2", stream_name="transformed-events-2"),
+            segment("sbc", msg_type=IngestMetric).sink(
+                "kafkasink", stream_name="transformed-events"
+            ),
+            segment("clickhouse", msg_type=IngestMetric).sink(
+                "kafkasink2", stream_name="transformed-events-2"
+            ),
         ],
     )
 )
 
 save_delayed_message = (
-    segment(name="delayed")
-    .apply("dump_msg_delayed", Map(json_dump_message))
+    segment(name="delayed", msg_type=IngestMetric)
+    .apply("serializer2", Serializer(serializer=json_serializer))
     .sink(
         "kafkasink3",
         stream_name="transformed-events-3",
@@ -30,9 +36,9 @@ save_delayed_message = (
 pipeline = (
     streaming_source(
         name="ingest",
-        stream_name="events",
+        stream_name="ingest-metrics",
     )
-    .apply("unpack_message", Map(unpack_kafka_message))
+    .apply("parser", Parser(msg_type=IngestMetric, deserializer=json_parser))
     .route(
         "blq_router",
         routing_function=should_send_to_blq,

--- a/sentry_streams/sentry_streams/examples/blq.py
+++ b/sentry_streams/sentry_streams/examples/blq.py
@@ -6,11 +6,10 @@ from sentry_streams.examples.blq_fn import (
 )
 from sentry_streams.pipeline import segment, streaming_source
 from sentry_streams.pipeline.chain import Parser, Serializer
-from sentry_streams.pipeline.msg_parser import msg_parser, msg_serializer
 
 storage_branch = (
     segment(name="recent", msg_type=IngestMetric)
-    .apply("serializer1", Serializer(serializer=msg_serializer))
+    .apply("serializer1", Serializer())
     .broadcast(
         "send_message_to_DBs",
         routes=[
@@ -26,7 +25,7 @@ storage_branch = (
 
 save_delayed_message = (
     segment(name="delayed", msg_type=IngestMetric)
-    .apply("serializer2", Serializer(serializer=msg_serializer))
+    .apply("serializer2", Serializer())
     .sink(
         "kafkasink3",
         stream_name="transformed-events-3",
@@ -38,7 +37,7 @@ pipeline = (
         name="ingest",
         stream_name="ingest-metrics",
     )
-    .apply("parser", Parser(msg_type=IngestMetric, deserializer=msg_parser))
+    .apply("parser", Parser(msg_type=IngestMetric))
     .route(
         "blq_router",
         routing_function=should_send_to_blq,

--- a/sentry_streams/sentry_streams/examples/blq.py
+++ b/sentry_streams/sentry_streams/examples/blq.py
@@ -6,11 +6,11 @@ from sentry_streams.examples.blq_fn import (
 )
 from sentry_streams.pipeline import segment, streaming_source
 from sentry_streams.pipeline.chain import Parser, Serializer
-from sentry_streams.pipeline.msg_parser import json_parser, json_serializer
+from sentry_streams.pipeline.msg_parser import msg_parser, msg_serializer
 
 storage_branch = (
     segment(name="recent", msg_type=IngestMetric)
-    .apply("serializer1", Serializer(serializer=json_serializer))
+    .apply("serializer1", Serializer(serializer=msg_serializer))
     .broadcast(
         "send_message_to_DBs",
         routes=[
@@ -26,7 +26,7 @@ storage_branch = (
 
 save_delayed_message = (
     segment(name="delayed", msg_type=IngestMetric)
-    .apply("serializer2", Serializer(serializer=json_serializer))
+    .apply("serializer2", Serializer(serializer=msg_serializer))
     .sink(
         "kafkasink3",
         stream_name="transformed-events-3",
@@ -38,7 +38,7 @@ pipeline = (
         name="ingest",
         stream_name="ingest-metrics",
     )
-    .apply("parser", Parser(msg_type=IngestMetric, deserializer=json_parser))
+    .apply("parser", Parser(msg_type=IngestMetric, deserializer=msg_parser))
     .route(
         "blq_router",
         routing_function=should_send_to_blq,

--- a/sentry_streams/sentry_streams/examples/blq_fn.py
+++ b/sentry_streams/sentry_streams/examples/blq_fn.py
@@ -1,8 +1,9 @@
-import json
 import time
-from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+
+from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
+
+from sentry_streams.pipeline.message import Message
 
 # 10 minutes
 MAX_MESSAGE_LATENCY = 600
@@ -13,33 +14,9 @@ class DownstreamBranch(Enum):
     RECENT = "recent"
 
 
-@dataclass
-class Message:
-    value: Any
-    timestamp: float
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "value": self.value,
-            "timestamp": self.timestamp,
-        }
-
-
-def unpack_kafka_message(msg: str) -> Message:
-    d = json.loads(msg)
-    return Message(
-        value=d["value"],
-        timestamp=d["timestamp"],
-    )
-
-
-def should_send_to_blq(msg: Message) -> DownstreamBranch:
-    timestamp = msg.timestamp
+def should_send_to_blq(msg: Message[IngestMetric]) -> DownstreamBranch:
+    timestamp = msg.payload["timestamp"]  # We can do this because the type of the payload is known
     if timestamp < time.time() - MAX_MESSAGE_LATENCY:
         return DownstreamBranch.DELAYED
     else:
         return DownstreamBranch.RECENT
-
-
-def json_dump_message(msg: Message) -> str:
-    return json.dumps(msg.to_dict())

--- a/sentry_streams/sentry_streams/examples/multi_chain.py
+++ b/sentry_streams/sentry_streams/examples/multi_chain.py
@@ -3,7 +3,7 @@ from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 from sentry_streams.pipeline import Map, multi_chain, streaming_source
 from sentry_streams.pipeline.chain import Parser, Serializer
 from sentry_streams.pipeline.message import Message
-from sentry_streams.pipeline.msg_parser import json_parser, json_serializer
+from sentry_streams.pipeline.msg_parser import msg_parser, msg_serializer
 
 
 def do_something(msg: Message[IngestMetric]) -> Message[IngestMetric]:
@@ -15,31 +15,31 @@ pipeline = multi_chain(
     [
         # Main Ingest chain
         streaming_source("ingest", stream_name="ingest-metrics")
-        .apply("parse_msg", Parser(msg_type=IngestMetric, deserializer=json_parser))
+        .apply("parse_msg", Parser(msg_type=IngestMetric, deserializer=msg_parser))
         .apply("process", Map(do_something))
-        .apply("serialize", Serializer(serializer=json_serializer))
+        .apply("serialize", Serializer(serializer=msg_serializer))
         .sink("eventstream", stream_name="events"),
         # Snuba chain to Clickhouse
         streaming_source("snuba", stream_name="ingest-metrics")
-        .apply("snuba_parse_msg", Parser(msg_type=IngestMetric, deserializer=json_parser))
-        .apply("snuba_serialize", Serializer(serializer=json_serializer))
+        .apply("snuba_parse_msg", Parser(msg_type=IngestMetric, deserializer=msg_parser))
+        .apply("snuba_serialize", Serializer(serializer=msg_serializer))
         .sink(
             "clickhouse",
             stream_name="someewhere",
         ),
         # Super Big Consumer chain
         streaming_source("sbc", stream_name="ingest-metrics")
-        .apply("sbc_parse_msg", Parser(msg_type=IngestMetric, deserializer=json_parser))
-        .apply("sbc_serialize", Serializer(serializer=json_serializer))
+        .apply("sbc_parse_msg", Parser(msg_type=IngestMetric, deserializer=msg_parser))
+        .apply("sbc_serialize", Serializer(serializer=msg_serializer))
         .sink(
             "sbc_sink",
             stream_name="someewhere",
         ),
         # Post process chain
         streaming_source("post_process", stream_name="ingest-metrics")
-        .apply("post_parse_msg", Parser(msg_type=IngestMetric, deserializer=json_parser))
+        .apply("post_parse_msg", Parser(msg_type=IngestMetric, deserializer=msg_parser))
         .apply("postprocess", Map(do_something))
-        .apply("postprocess_serialize", Serializer(serializer=json_serializer))
+        .apply("postprocess_serialize", Serializer(serializer=msg_serializer))
         .sink(
             "devnull",
             stream_name="someewhereelse",

--- a/sentry_streams/sentry_streams/examples/multi_chain.py
+++ b/sentry_streams/sentry_streams/examples/multi_chain.py
@@ -1,23 +1,12 @@
-from json import JSONDecodeError, dumps, loads
-from typing import Any, Mapping, cast
+from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 
 from sentry_streams.pipeline import Map, multi_chain, streaming_source
+from sentry_streams.pipeline.chain import Parser, Serializer
+from sentry_streams.pipeline.message import Message
+from sentry_streams.pipeline.msg_parser import json_parser, json_serializer
 
 
-def parse(msg: str) -> Mapping[str, Any]:
-    try:
-        parsed = loads(msg)
-    except JSONDecodeError:
-        return {"type": "invalid"}
-
-    return cast(Mapping[str, Any], parsed)
-
-
-def serialize(msg: Mapping[str, Any]) -> str:
-    return dumps(msg)
-
-
-def do_something(msg: Mapping[str, Any]) -> Mapping[str, Any]:
+def do_something(msg: Message[IngestMetric]) -> Message[IngestMetric]:
     # Do something with the message
     return msg
 
@@ -25,29 +14,32 @@ def do_something(msg: Mapping[str, Any]) -> Mapping[str, Any]:
 pipeline = multi_chain(
     [
         # Main Ingest chain
-        streaming_source("ingest", stream_name="ingest-events")
-        .apply("parse_msg", Map(parse))
+        streaming_source("ingest", stream_name="ingest-metrics")
+        .apply("parse_msg", Parser(msg_type=IngestMetric, deserializer=json_parser))
         .apply("process", Map(do_something))
-        .apply("serialize", Map(serialize))
+        .apply("serialize", Serializer(serializer=json_serializer))
         .sink("eventstream", stream_name="events"),
         # Snuba chain to Clickhouse
-        streaming_source("snuba", stream_name="events")
-        .apply("snuba_parse_msg", Map(parse))
+        streaming_source("snuba", stream_name="ingest-metrics")
+        .apply("snuba_parse_msg", Parser(msg_type=IngestMetric, deserializer=json_parser))
+        .apply("snuba_serialize", Serializer(serializer=json_serializer))
         .sink(
             "clickhouse",
             stream_name="someewhere",
         ),
         # Super Big Consumer chain
-        streaming_source("sbc", stream_name="events")
-        .apply("sbc_parse_msg", Map(parse))
+        streaming_source("sbc", stream_name="ingest-metrics")
+        .apply("sbc_parse_msg", Parser(msg_type=IngestMetric, deserializer=json_parser))
+        .apply("sbc_serialize", Serializer(serializer=json_serializer))
         .sink(
             "sbc_sink",
             stream_name="someewhere",
         ),
         # Post process chain
-        streaming_source("post_process", stream_name="events")
-        .apply("post_parse_msg", Map(parse))
+        streaming_source("post_process", stream_name="ingest-metrics")
+        .apply("post_parse_msg", Parser(msg_type=IngestMetric, deserializer=json_parser))
         .apply("postprocess", Map(do_something))
+        .apply("postprocess_serialize", Serializer(serializer=json_serializer))
         .sink(
             "devnull",
             stream_name="someewhereelse",

--- a/sentry_streams/sentry_streams/examples/transformer.py
+++ b/sentry_streams/sentry_streams/examples/transformer.py
@@ -54,20 +54,6 @@ class TransformerBatch(Accumulator[Any, Any]):
 
 reduce_window = SlidingWindow(window_size=timedelta(seconds=6), window_slide=timedelta(seconds=2))
 
-# chain1 = streaming_source(
-#     name="myinput",
-#     stream_name="events",
-# )
-
-# chain2 = chain1.apply("parser", Parser(deserializer=json_parser))
-# chain3 = chain2.apply("myfilter", Filter(function=filter_not_event))
-# chain4 = chain3.apply("myreduce", Reducer(reduce_window, TransformerBatch))
-# chain5 = chain4.apply("serializer", Map(function=serialize_msg))
-# chain6 = chain5.sink(
-#     "kafkasink2", stream_name="transformed-events"
-# )  # flush the batches to the Sink
-
-
 pipeline = (
     streaming_source(
         name="myinput",

--- a/sentry_streams/sentry_streams/examples/transformer.py
+++ b/sentry_streams/sentry_streams/examples/transformer.py
@@ -12,7 +12,6 @@ from sentry_streams.pipeline.chain import (
 )
 from sentry_streams.pipeline.function_template import Accumulator
 from sentry_streams.pipeline.message import Message
-from sentry_streams.pipeline.msg_parser import msg_parser, msg_serializer
 from sentry_streams.pipeline.window import SlidingWindow
 
 # The simplest possible pipeline.
@@ -54,7 +53,7 @@ pipeline = streaming_source(
 chain1 = pipeline.apply(
     "parser",
     Parser(
-        msg_type=IngestMetric, deserializer=msg_parser
+        msg_type=IngestMetric,
     ),  # pass in the standard message parser function
 )  # ExtensibleChain[Message[IngestMetric]]
 
@@ -64,7 +63,7 @@ chain2 = chain1.apply(
 
 chain3 = chain2.apply(
     "serializer",
-    Serializer(serializer=msg_serializer),  # pass in the standard message serializer function
+    Serializer(),  # pass in the standard message serializer function
 )  # ExtensibleChain[bytes]
 
 chain4 = chain3.sink(

--- a/sentry_streams/sentry_streams/examples/transformer.py
+++ b/sentry_streams/sentry_streams/examples/transformer.py
@@ -33,13 +33,13 @@ def serialize_msg(msg: Mapping[str, Any]) -> str:
     return dumps(msg)
 
 
-class TransformerBatch(Accumulator[Any, Any]):
+class TransformerBatch(Accumulator[Message[Mapping[str, Any]], Message[Mapping[str, Any]]]):
 
     def __init__(self) -> None:
         self.batch: MutableSequence[Any] = []
 
-    def add(self, value: Any) -> Self:
-        self.batch.append(value.payload["test"])  # deal with Message
+    def add(self, value: Message[Mapping[str, Any]]) -> Self:
+        self.batch.append(value.payload["test"])
 
         return self
 
@@ -54,6 +54,22 @@ class TransformerBatch(Accumulator[Any, Any]):
 
 
 reduce_window = SlidingWindow(window_size=timedelta(seconds=6), window_slide=timedelta(seconds=2))
+
+
+# pipeline = (
+#     streaming_source(
+#         name="myinput",
+#         stream_name="events",
+#     )
+#     .apply("parser", Parser(deserializer=json_parser))
+#     .apply("myfilter", Filter(function=filter_not_event))
+#     .apply("myreduce", Reducer(reduce_window, TransformerBatch))
+#     .sink(
+#         "kafkasink2",
+#         stream_name="transformed-events",
+#         serializer=json_serializer,
+#     )  # flush the batches to the Sink
+
 
 pipeline = (
     streaming_source(

--- a/sentry_streams/sentry_streams/examples/transformer.py
+++ b/sentry_streams/sentry_streams/examples/transformer.py
@@ -1,13 +1,17 @@
 from datetime import timedelta
+from typing import Any, MutableSequence, Optional, Self
 
+from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 
 from sentry_streams.pipeline import streaming_source
 from sentry_streams.pipeline.chain import (
-    Batch,
     Parser,
+    Reducer,
     Serializer,
 )
+from sentry_streams.pipeline.function_template import Accumulator
+from sentry_streams.pipeline.message import Message
 from sentry_streams.pipeline.msg_parser import json_parser, json_serializer
 from sentry_streams.pipeline.window import SlidingWindow
 
@@ -19,55 +23,40 @@ from sentry_streams.pipeline.window import SlidingWindow
 # - produces the event on Kafka
 
 
-# def parse(msg: str) -> Mapping[str, Any]:
-#     try:
-#         parsed = loads(msg)
-#     except JSONDecodeError:
-#         return {"type": "invalid"}
+class TransformerBatch(Accumulator[Message[IngestMetric], Message[MutableSequence[IngestMetric]]]):
 
-#     return cast(Mapping[str, Any], parsed)
+    def __init__(self) -> None:
+        self.batch: MutableSequence[IngestMetric] = []
+        self.schema: Optional[Codec[Any]] = None
 
+    def add(self, value: Message[IngestMetric]) -> Self:
+        self.batch.append(value.payload)
+        if self.schema is None:
+            self.schema = value.schema
 
-# def filter_not_event(msg: Message[Mapping[str, Any]]) -> bool:
-#     return bool(msg.payload["type"] == "event")
+        return self
 
+    def get_value(self) -> Message[MutableSequence[IngestMetric]]:
+        return Message(self.batch, self.schema)
 
-# def serialize_msg(msg: Mapping[str, Any]) -> str:
-#     return dumps(msg)
+    def merge(self, other: Self) -> Self:
+        self.batch.extend(other.batch)
 
-
-# class TransformerBatch(Accumulator[Message[IngestMetric], Message[MutableSequence[IngestMetric]]]):
-
-#     def __init__(self) -> None:
-#         self.batch: MutableSequence[Any] = []
-
-#     def add(self, value: Message[IngestMetric]) -> Self:
-#         self.batch.append(value.payload)
-#         self.schema = value.schema
-
-#         return self
-
-#     def get_value(self) -> Any:
-#         return Message(self.schema, self.batch)
-
-#     def merge(self, other: Self) -> Self:
-#         self.batch.extend(other.batch)
-
-#         return self
+        return self
 
 
 reduce_window = SlidingWindow(window_size=timedelta(seconds=6), window_slide=timedelta(seconds=2))
 
-pipeline = (
-    streaming_source(
-        name="myinput",
-        stream_name="ingest-metrics",
-    )
-    .apply("parser", Parser(deserializer=json_parser, msg_type=IngestMetric))
-    .apply("batcher", Batch(batch_size=5))
-    .apply("serializer", Serializer(serializer=json_serializer))
-    .sink(
-        "kafkasink2",
-        stream_name="transformed-events",
-    )  # flush the batches to the Sink
-)
+pipeline = streaming_source(name="myinput", stream_name="ingest-metrics")
+
+chain2 = pipeline.apply("parser", Parser(msg_type=IngestMetric, deserializer=json_parser))
+
+chain3 = chain2.apply("batcher", Reducer(reduce_window, TransformerBatch))
+
+chain4 = chain3.apply(
+    "serializer",
+    Serializer(serializer=json_serializer),
+).sink(
+    "kafkasink2",
+    stream_name="transformed-events",
+)  # flush the batches to the Sink

--- a/sentry_streams/sentry_streams/examples/transformer.py
+++ b/sentry_streams/sentry_streams/examples/transformer.py
@@ -2,10 +2,17 @@ from datetime import timedelta
 from json import JSONDecodeError, dumps, loads
 from typing import Any, Mapping, MutableSequence, Self, cast
 
-from sentry_streams.pipeline import Filter, streaming_source
-from sentry_streams.pipeline.chain import Parser, Reducer
+from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
+
+from sentry_streams.pipeline import streaming_source
+from sentry_streams.pipeline.chain import (
+    Message,
+    Parser,
+    Reducer,
+    Serializer,
+)
 from sentry_streams.pipeline.function_template import Accumulator
-from sentry_streams.pipeline.msg_parser import json_parser, json_serializer
+from sentry_streams.pipeline.msg_parser import json_serializer
 from sentry_streams.pipeline.window import SlidingWindow
 
 # The simplest possible pipeline.
@@ -25,26 +32,27 @@ def parse(msg: str) -> Mapping[str, Any]:
     return cast(Mapping[str, Any], parsed)
 
 
-def filter_not_event(msg: Mapping[str, Any]) -> bool:
-    return bool(msg["type"] == "event")
+def filter_not_event(msg: Message[Mapping[str, Any]]) -> bool:
+    return bool(msg.payload["type"] == "event")
 
 
 def serialize_msg(msg: Mapping[str, Any]) -> str:
     return dumps(msg)
 
 
-class TransformerBatch(Accumulator[Mapping[str, Any], Mapping[str, Any]]):
+class TransformerBatch(Accumulator[Message[IngestMetric], Message[MutableSequence[IngestMetric]]]):
 
     def __init__(self) -> None:
         self.batch: MutableSequence[Any] = []
 
-    def add(self, value: Mapping[str, Any]) -> Self:
-        self.batch.append(value["test"])
+    def add(self, value: Message[IngestMetric]) -> Self:
+        self.batch.append(value.payload)
+        self.schema = value.schema
 
         return self
 
     def get_value(self) -> Any:
-        return "".join(self.batch)
+        return Message(self.schema, self.batch)
 
     def merge(self, other: Self) -> Self:
         self.batch.extend(other.batch)
@@ -57,14 +65,15 @@ reduce_window = SlidingWindow(window_size=timedelta(seconds=6), window_slide=tim
 pipeline = (
     streaming_source(
         name="myinput",
-        stream_name="events",
+        stream_name="ingest-metrics",
     )
-    .apply("parser", Parser(deserializer=json_parser))
-    .apply("myfilter", Filter(function=filter_not_event))
+    .apply(
+        "parser", Parser(msg_type=IngestMetric)
+    )  # All the user should have to say is JSON or protobuf?
     .apply("myreduce", Reducer(reduce_window, TransformerBatch))
+    .apply("serialzier", Serializer(serializer=json_serializer))
     .sink(
         "kafkasink2",
         stream_name="transformed-events",
-        serializer=json_serializer,
     )  # flush the batches to the Sink
 )

--- a/sentry_streams/sentry_streams/examples/transformer.py
+++ b/sentry_streams/sentry_streams/examples/transformer.py
@@ -15,13 +15,12 @@ from sentry_streams.pipeline.window import SlidingWindow
 
 # The simplest possible pipeline.
 # - reads from Kafka
-# - parses the event
-# - filters the event based on an attribute
-# - serializes the event into json
+# - parses the metric data, validating against schema
+# - batches messages together, emits aggregate results based on sliding window configuration
+# - serializes the result into bytes
 # - produces the event on Kafka
 
 
-# make this return the actual payload, add a Map next step with no headers
 class TransformerBatch(Accumulator[Message[IngestMetric], MutableSequence[IngestMetric]]):
 
     def __init__(self) -> None:

--- a/sentry_streams/sentry_streams/examples/transformer.py
+++ b/sentry_streams/sentry_streams/examples/transformer.py
@@ -1,18 +1,14 @@
 from datetime import timedelta
-from json import JSONDecodeError, dumps, loads
-from typing import Any, Mapping, MutableSequence, Self, cast
 
 from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 
 from sentry_streams.pipeline import streaming_source
 from sentry_streams.pipeline.chain import (
-    Message,
+    Batch,
     Parser,
-    Reducer,
     Serializer,
 )
-from sentry_streams.pipeline.function_template import Accumulator
-from sentry_streams.pipeline.msg_parser import json_serializer
+from sentry_streams.pipeline.msg_parser import json_parser, json_serializer
 from sentry_streams.pipeline.window import SlidingWindow
 
 # The simplest possible pipeline.
@@ -23,41 +19,41 @@ from sentry_streams.pipeline.window import SlidingWindow
 # - produces the event on Kafka
 
 
-def parse(msg: str) -> Mapping[str, Any]:
-    try:
-        parsed = loads(msg)
-    except JSONDecodeError:
-        return {"type": "invalid"}
+# def parse(msg: str) -> Mapping[str, Any]:
+#     try:
+#         parsed = loads(msg)
+#     except JSONDecodeError:
+#         return {"type": "invalid"}
 
-    return cast(Mapping[str, Any], parsed)
-
-
-def filter_not_event(msg: Message[Mapping[str, Any]]) -> bool:
-    return bool(msg.payload["type"] == "event")
+#     return cast(Mapping[str, Any], parsed)
 
 
-def serialize_msg(msg: Mapping[str, Any]) -> str:
-    return dumps(msg)
+# def filter_not_event(msg: Message[Mapping[str, Any]]) -> bool:
+#     return bool(msg.payload["type"] == "event")
 
 
-class TransformerBatch(Accumulator[Message[IngestMetric], Message[MutableSequence[IngestMetric]]]):
+# def serialize_msg(msg: Mapping[str, Any]) -> str:
+#     return dumps(msg)
 
-    def __init__(self) -> None:
-        self.batch: MutableSequence[Any] = []
 
-    def add(self, value: Message[IngestMetric]) -> Self:
-        self.batch.append(value.payload)
-        self.schema = value.schema
+# class TransformerBatch(Accumulator[Message[IngestMetric], Message[MutableSequence[IngestMetric]]]):
 
-        return self
+#     def __init__(self) -> None:
+#         self.batch: MutableSequence[Any] = []
 
-    def get_value(self) -> Any:
-        return Message(self.schema, self.batch)
+#     def add(self, value: Message[IngestMetric]) -> Self:
+#         self.batch.append(value.payload)
+#         self.schema = value.schema
 
-    def merge(self, other: Self) -> Self:
-        self.batch.extend(other.batch)
+#         return self
 
-        return self
+#     def get_value(self) -> Any:
+#         return Message(self.schema, self.batch)
+
+#     def merge(self, other: Self) -> Self:
+#         self.batch.extend(other.batch)
+
+#         return self
 
 
 reduce_window = SlidingWindow(window_size=timedelta(seconds=6), window_slide=timedelta(seconds=2))
@@ -67,11 +63,9 @@ pipeline = (
         name="myinput",
         stream_name="ingest-metrics",
     )
-    .apply(
-        "parser", Parser(msg_type=IngestMetric)
-    )  # All the user should have to say is JSON or protobuf?
-    .apply("myreduce", Reducer(reduce_window, TransformerBatch))
-    .apply("serialzier", Serializer(serializer=json_serializer))
+    .apply("parser", Parser(deserializer=json_parser, msg_type=IngestMetric))
+    .apply("batcher", Batch(batch_size=5))
+    .apply("serializer", Serializer(serializer=json_serializer))
     .sink(
         "kafkasink2",
         stream_name="transformed-events",

--- a/sentry_streams/sentry_streams/examples/transformer.py
+++ b/sentry_streams/sentry_streams/examples/transformer.py
@@ -12,7 +12,7 @@ from sentry_streams.pipeline.chain import (
 )
 from sentry_streams.pipeline.function_template import Accumulator
 from sentry_streams.pipeline.message import Message
-from sentry_streams.pipeline.msg_parser import json_parser, json_serializer
+from sentry_streams.pipeline.msg_parser import msg_parser, msg_serializer
 from sentry_streams.pipeline.window import SlidingWindow
 
 # The simplest possible pipeline.
@@ -52,7 +52,7 @@ pipeline = streaming_source(
 )  # ExtensibleChain[Message[bytes]]
 
 chain1 = pipeline.apply(
-    "parser", Parser(msg_type=IngestMetric, deserializer=json_parser)
+    "parser", Parser(msg_type=IngestMetric, deserializer=msg_parser)
 )  # ExtensibleChain[Message[IngestMetric]]
 
 chain2 = chain1.apply(
@@ -61,7 +61,7 @@ chain2 = chain1.apply(
 
 chain3 = chain2.apply(
     "serializer",
-    Serializer(serializer=json_serializer),
+    Serializer(serializer=msg_serializer),
 )  # ExtensibleChain[bytes]
 
 chain4 = chain3.sink(

--- a/sentry_streams/sentry_streams/examples/transformer.py
+++ b/sentry_streams/sentry_streams/examples/transformer.py
@@ -52,7 +52,10 @@ pipeline = streaming_source(
 )  # ExtensibleChain[Message[bytes]]
 
 chain1 = pipeline.apply(
-    "parser", Parser(msg_type=IngestMetric, deserializer=msg_parser)
+    "parser",
+    Parser(
+        msg_type=IngestMetric, deserializer=msg_parser
+    ),  # pass in the standard message parser function
 )  # ExtensibleChain[Message[IngestMetric]]
 
 chain2 = chain1.apply(
@@ -61,7 +64,7 @@ chain2 = chain1.apply(
 
 chain3 = chain2.apply(
     "serializer",
-    Serializer(serializer=msg_serializer),
+    Serializer(serializer=msg_serializer),  # pass in the standard message serializer function
 )  # ExtensibleChain[bytes]
 
 chain4 = chain3.sink(

--- a/sentry_streams/sentry_streams/examples/transformer.py
+++ b/sentry_streams/sentry_streams/examples/transformer.py
@@ -2,9 +2,10 @@ from datetime import timedelta
 from json import JSONDecodeError, dumps, loads
 from typing import Any, Mapping, MutableSequence, Self, cast
 
-from sentry_streams.pipeline import Filter, Map, streaming_source
-from sentry_streams.pipeline.chain import Reducer
+from sentry_streams.pipeline import Filter, streaming_source
+from sentry_streams.pipeline.chain import Parser, Reducer
 from sentry_streams.pipeline.function_template import Accumulator
+from sentry_streams.pipeline.msg_parser import json_parser, json_serializer
 from sentry_streams.pipeline.window import SlidingWindow
 
 # The simplest possible pipeline.
@@ -53,17 +54,31 @@ class TransformerBatch(Accumulator[Any, Any]):
 
 reduce_window = SlidingWindow(window_size=timedelta(seconds=6), window_slide=timedelta(seconds=2))
 
+# chain1 = streaming_source(
+#     name="myinput",
+#     stream_name="events",
+# )
+
+# chain2 = chain1.apply("parser", Parser(deserializer=json_parser))
+# chain3 = chain2.apply("myfilter", Filter(function=filter_not_event))
+# chain4 = chain3.apply("myreduce", Reducer(reduce_window, TransformerBatch))
+# chain5 = chain4.apply("serializer", Map(function=serialize_msg))
+# chain6 = chain5.sink(
+#     "kafkasink2", stream_name="transformed-events"
+# )  # flush the batches to the Sink
+
+
 pipeline = (
     streaming_source(
         name="myinput",
         stream_name="events",
     )
-    .apply("mymap", Map(function=parse))
+    .apply("parser", Parser(deserializer=json_parser))
     .apply("myfilter", Filter(function=filter_not_event))
     .apply("myreduce", Reducer(reduce_window, TransformerBatch))
-    .apply("serializer", Map(function=serialize_msg))
     .sink(
         "kafkasink2",
         stream_name="transformed-events",
+        serializer=json_serializer,
     )  # flush the batches to the Sink
 )

--- a/sentry_streams/sentry_streams/pipeline/batch.py
+++ b/sentry_streams/sentry_streams/pipeline/batch.py
@@ -34,7 +34,9 @@ class BatchBuilder(Accumulator[Message[InputType], Message[MutableSequence[Input
         return self
 
 
-def unbatch(batch: MutableSequence[InputType]) -> Generator[InputType, None, None]:
+def unbatch(
+    batch: Message[MutableSequence[InputType]],
+) -> Generator[Message[InputType], None, None]:
     """
     Takes in a generic batch representation, outputs a Generator type for iterating over
     individual elements which compose the batch.
@@ -42,5 +44,7 @@ def unbatch(batch: MutableSequence[InputType]) -> Generator[InputType, None, Non
     The data type of the elements remains the same through this operation. This operation
     may need to be followed by a Map or other transformation if a new output type is expected.
     """
-    for message in batch:
-        yield message
+    schema = batch.schema
+
+    for payload in batch.payload:
+        yield Message(payload, schema)

--- a/sentry_streams/sentry_streams/pipeline/chain.py
+++ b/sentry_streams/sentry_streams/pipeline/chain.py
@@ -289,12 +289,12 @@ class ExtensibleChain(Chain, Generic[TIn]):
         return self
 
 
-def segment(name: str) -> ExtensibleChain[TIn]:
+def segment(name: str, msg_type: Type[TIn]) -> ExtensibleChain[Message[TIn]]:
     """
     Creates a segment of a pipeline to be referenced in existing pipelines
     in route and broadcast steps.
     """
-    pipeline: ExtensibleChain[TIn] = ExtensibleChain(name)
+    pipeline: ExtensibleChain[Message[TIn]] = ExtensibleChain(name)
     pipeline._add_start(Branch(name=name, ctx=pipeline))
     return pipeline
 

--- a/sentry_streams/sentry_streams/pipeline/chain.py
+++ b/sentry_streams/sentry_streams/pipeline/chain.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import (
-    Any,
     Callable,
     Generic,
     Mapping,
@@ -25,6 +24,7 @@ from sentry_streams.pipeline.function_template import (
     OutputType,
 )
 from sentry_streams.pipeline.message import Message
+from sentry_streams.pipeline.msg_parser import msg_parser, msg_serializer
 from sentry_streams.pipeline.pipeline import (
     Aggregate,
 )
@@ -122,31 +122,28 @@ class Reducer(
 @dataclass
 class Parser(Applier[Message[bytes], Message[TOut]], Generic[TOut]):
     msg_type: Type[TOut]
-    deserializer: Union[
-        Callable[[Message[bytes]], Message[TOut]], str
-    ]  # This has to be a type-annotated function so that the type of TOut can be inferred
+    # deserializer: Union[
+    #     Callable[[Message[bytes]], Message[TOut]], str
+    # ]  # This has to be a type-annotated function so that the type of TOut can be inferred
 
     def build_step(self, name: str, ctx: Pipeline, previous: Step) -> Step:
         return MapStep(
             name=name,
             ctx=ctx,
             inputs=[previous],
-            function=self.deserializer,
+            function=msg_parser,
         )
 
 
 @dataclass
 class Serializer(Applier[Message[TIn], bytes], Generic[TIn]):
-    serializer: Union[
-        Callable[[Message[Any]], bytes], str
-    ]  # This has to be a type-annotated function so that the type of TOut can be inferred
 
     def build_step(self, name: str, ctx: Pipeline, previous: Step) -> Step:
         return MapStep(
             name=name,
             ctx=ctx,
             inputs=[previous],
-            function=self.serializer,
+            function=msg_serializer,
         )
 
 

--- a/sentry_streams/sentry_streams/pipeline/chain.py
+++ b/sentry_streams/sentry_streams/pipeline/chain.py
@@ -8,6 +8,7 @@ from typing import (
     Callable,
     Generic,
     Mapping,
+    MutableMapping,
     MutableSequence,
     Optional,
     Sequence,
@@ -56,9 +57,8 @@ TOut = TypeVar("TOut")
 # a message with a generic payload
 class Message(Generic[TIn]):
     payload: TIn
-    key: Optional[bytes]
-    value: bytes
-    headers: MutableSequence[Tuple[str, bytes]]
+    # schema: ...
+    additional: Optional[MutableMapping[str, Any]]
 
 
 @dataclass
@@ -291,15 +291,15 @@ def segment(name: str) -> ExtensibleChain[TIn]:
     return pipeline
 
 
-def streaming_source(name: str, stream_name: str) -> ExtensibleChain[bytes]:
+def streaming_source(
+    name: str, stream_name: str, header_filter: Optional[Tuple[str, bytes]] = None
+) -> ExtensibleChain[bytes]:
     """
     Create a pipeline that starts with a StreamingSource.
     """
     pipeline: ExtensibleChain[bytes] = ExtensibleChain("root")
     source = StreamSource(
-        name=name,
-        ctx=pipeline,
-        stream_name=stream_name,
+        name=name, ctx=pipeline, stream_name=stream_name, header_filter=header_filter
     )
     pipeline._add_start(source)
     return pipeline

--- a/sentry_streams/sentry_streams/pipeline/chain.py
+++ b/sentry_streams/sentry_streams/pipeline/chain.py
@@ -315,8 +315,3 @@ def multi_chain(chains: Sequence[Chain]) -> Pipeline:
     for chain in chains:
         pipeline.add(chain)
     return pipeline
-
-
-# 1. Introduce generic linking between steps
-# 2. Flesh out source and sink by adding serialization and deserialization
-#    1. Offer a few different serializers and deserializers out of the box

--- a/sentry_streams/sentry_streams/pipeline/chain.py
+++ b/sentry_streams/sentry_streams/pipeline/chain.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import (
+    Any,
     Callable,
     Generic,
     Mapping,
@@ -120,10 +121,10 @@ class Reducer(
 
 @dataclass
 class Parser(Applier[Message[bytes], Message[TOut]], Generic[TOut]):
+    msg_type: Type[TOut]
     deserializer: Union[
         Callable[[Message[bytes]], Message[TOut]], str
     ]  # This has to be a type-annotated function so that the type of TOut can be inferred
-    msg_type: Type[TOut]
 
     def build_step(self, name: str, ctx: Pipeline, previous: Step) -> Step:
         return MapStep(
@@ -137,7 +138,7 @@ class Parser(Applier[Message[bytes], Message[TOut]], Generic[TOut]):
 @dataclass
 class Serializer(Applier[Message[TIn], bytes], Generic[TIn]):
     serializer: Union[
-        Callable[[Message[TIn]], bytes], str
+        Callable[[Message[Any]], bytes], str
     ]  # This has to be a type-annotated function so that the type of TOut can be inferred
 
     def build_step(self, name: str, ctx: Pipeline, previous: Step) -> Step:

--- a/sentry_streams/sentry_streams/pipeline/chain.py
+++ b/sentry_streams/sentry_streams/pipeline/chain.py
@@ -91,7 +91,7 @@ class Filter(Applier[Message[TIn], Message[TIn]], Generic[TIn]):
 
 @dataclass
 class FlatMap(Applier[Message[TIn], Message[TOut]], Generic[TIn, TOut]):
-    function: Union[Callable[[Message[TIn]], TOut], str]  # Should be an iterator output
+    function: Union[Callable[[Message[TIn]], TOut], str]  # Change the type here
 
     def build_step(self, name: str, ctx: Pipeline, previous: Step) -> Step:
         return FlatMapStep(name=name, ctx=ctx, inputs=[previous], function=self.function)

--- a/sentry_streams/sentry_streams/pipeline/message.py
+++ b/sentry_streams/sentry_streams/pipeline/message.py
@@ -13,10 +13,12 @@ from sentry_kafka_schemas.codecs import Codec
 TIn = TypeVar("TIn")
 
 
-# a message with a generic payload
+# A message with a generic payload
 class Message(Generic[TIn]):
     payload: TIn
-    schema: Optional[Codec[Any]]
+    schema: Optional[
+        Codec[Any]
+    ]  # The schema of incoming messages. This is optional so Messages can be flexibly initialized in any part of the pipeline. We may want to change this down the road.
     additional: Optional[MutableMapping[str, Any]]
 
     def __init__(self, payload: Any, schema: Optional[Codec[Any]] = None) -> None:

--- a/sentry_streams/sentry_streams/pipeline/message.py
+++ b/sentry_streams/sentry_streams/pipeline/message.py
@@ -12,7 +12,7 @@ from typing import (
 
 from sentry_kafka_schemas.codecs import Codec
 
-TIn = TypeVar("TIn")
+TIn = TypeVar("TIn")  # TODO: Consider naming this TPayload
 
 
 # A message with a generic payload

--- a/sentry_streams/sentry_streams/pipeline/message.py
+++ b/sentry_streams/sentry_streams/pipeline/message.py
@@ -24,3 +24,4 @@ class Message(Generic[TIn]):
     schema: Optional[
         Codec[Any]
     ]  # The schema of incoming messages. This is optional so Messages can be flexibly initialized in any part of the pipeline. We may want to change this down the road.
+    # TODO: Add support for an event timestamp

--- a/sentry_streams/sentry_streams/pipeline/message.py
+++ b/sentry_streams/sentry_streams/pipeline/message.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import (
+    Any,
+    Generic,
+    MutableMapping,
+    Optional,
+    TypeVar,
+)
+
+from sentry_kafka_schemas.codecs import Codec
+
+TIn = TypeVar("TIn")
+
+
+# a message with a generic payload
+class Message(Generic[TIn]):
+    payload: TIn
+    schema: Optional[Codec[Any]]
+    additional: Optional[MutableMapping[str, Any]]
+
+    def __init__(self, payload: Any, schema: Optional[Codec[Any]] = None) -> None:
+        self.payload = payload
+        self.schema = schema
+
+    def replace_payload(self, p: TIn) -> None:
+        self.payload = p

--- a/sentry_streams/sentry_streams/pipeline/message.py
+++ b/sentry_streams/sentry_streams/pipeline/message.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import (
     Any,
     Generic,
-    MutableMapping,
+    MutableSequence,
     Optional,
+    Tuple,
     TypeVar,
 )
 
@@ -14,16 +16,11 @@ TIn = TypeVar("TIn")
 
 
 # A message with a generic payload
+@dataclass(frozen=True)
 class Message(Generic[TIn]):
     payload: TIn
+    headers: MutableSequence[Tuple[str, bytes]]
+    timestamp: float
     schema: Optional[
         Codec[Any]
     ]  # The schema of incoming messages. This is optional so Messages can be flexibly initialized in any part of the pipeline. We may want to change this down the road.
-    additional: Optional[MutableMapping[str, Any]]
-
-    def __init__(self, payload: Any, schema: Optional[Codec[Any]] = None) -> None:
-        self.payload = payload
-        self.schema = schema
-
-    def replace_payload(self, p: TIn) -> None:
-        self.payload = p

--- a/sentry_streams/sentry_streams/pipeline/msg_parser.py
+++ b/sentry_streams/sentry_streams/pipeline/msg_parser.py
@@ -3,6 +3,9 @@ from typing import Any
 
 from sentry_streams.pipeline.message import Message
 
+# Standard message decoders and encoders live here
+# Choose between transports like JSON, protobuf
+
 
 def json_parser(msg: Message[bytes]) -> Message[Any]:
     schema = msg.schema

--- a/sentry_streams/sentry_streams/pipeline/msg_parser.py
+++ b/sentry_streams/sentry_streams/pipeline/msg_parser.py
@@ -1,20 +1,15 @@
 from json import JSONDecodeError, dumps, loads
 from typing import Any, Mapping, cast
 
-from sentry_streams.pipeline.chain import Message
 
-
-def json_parser(msg: bytes) -> Message[Mapping[str, Any]]:
+def json_parser(msg: bytes) -> Mapping[str, Any]:
     try:
         parsed = loads(msg)
     except JSONDecodeError:
-        new_msg: Message[Mapping[str, Any]] = Message({"type": "invalid"})
-        return new_msg
+        return {"type": "invalid"}
 
-    cast(Mapping[str, Any], parsed)
-    new_msg = Message(parsed)
-    return new_msg
+    return cast(Mapping[str, Any], parsed)
 
 
-def json_serializer(msg: Message[Mapping[str, Any]]) -> Message[str]:
-    return Message(dumps(msg.payload))
+def json_serializer(msg: Mapping[str, Any]) -> str:
+    return dumps(msg)

--- a/sentry_streams/sentry_streams/pipeline/msg_parser.py
+++ b/sentry_streams/sentry_streams/pipeline/msg_parser.py
@@ -1,15 +1,20 @@
 from json import JSONDecodeError, dumps, loads
 from typing import Any, Mapping, cast
 
+from sentry_streams.pipeline.chain import Message
 
-def json_parser(msg: bytes) -> Mapping[str, Any]:
+
+def json_parser(msg: bytes) -> Message[Mapping[str, Any]]:
     try:
         parsed = loads(msg)
     except JSONDecodeError:
-        return {"type": "invalid"}
+        new_msg: Message[Mapping[str, Any]] = Message({"type": "invalid"})
+        return new_msg
 
-    return cast(Mapping[str, Any], parsed)
+    cast(Mapping[str, Any], parsed)
+    new_msg = Message(parsed)
+    return new_msg
 
 
-def json_serializer(msg: Mapping[str, Any]) -> Any:
-    return dumps(msg)
+def json_serializer(msg: Message[Mapping[str, Any]]) -> Any:
+    return dumps(msg.payload)

--- a/sentry_streams/sentry_streams/pipeline/msg_parser.py
+++ b/sentry_streams/sentry_streams/pipeline/msg_parser.py
@@ -1,15 +1,14 @@
 import json
-import logging
 from typing import Any
 
 from sentry_streams.pipeline.message import Message
 
-logger = logging.getLogger(__name__)
-
 
 def json_parser(msg: Message[bytes]) -> Message[Any]:
     schema = msg.schema
-    assert schema is not None
+    assert (
+        schema is not None
+    )  # Message cannot be deserialized without a schema, this should be automatically inferred by stream sources
 
     payload = msg.payload
 

--- a/sentry_streams/sentry_streams/pipeline/msg_parser.py
+++ b/sentry_streams/sentry_streams/pipeline/msg_parser.py
@@ -16,5 +16,5 @@ def json_parser(msg: bytes) -> Message[Mapping[str, Any]]:
     return new_msg
 
 
-def json_serializer(msg: Message[Mapping[str, Any]]) -> Any:
-    return dumps(msg.payload)
+def json_serializer(msg: Message[Mapping[str, Any]]) -> Message[str]:
+    return Message(dumps(msg.payload))

--- a/sentry_streams/sentry_streams/pipeline/msg_parser.py
+++ b/sentry_streams/sentry_streams/pipeline/msg_parser.py
@@ -1,27 +1,22 @@
-from typing import Any, TypeVar
+import json
+import logging
+from typing import Any
 
-from sentry_kafka_schemas.codecs import Codec
+from sentry_streams.pipeline.message import Message
 
-from sentry_streams.pipeline.chain import Message
-
-T = TypeVar("T")
+logger = logging.getLogger(__name__)
 
 
 def json_parser(msg: Message[bytes]) -> Message[Any]:
+    schema = msg.schema
+    assert schema is not None
 
-    schema: Codec[Any] = msg.schema
     payload = msg.payload
 
     decoded = schema.decode(payload, True)
 
-    return Message(schema, decoded)
+    return Message(decoded, schema)
 
 
 def json_serializer(msg: Message[Any]) -> bytes:
-
-    schema: Codec[Any] = msg.schema
-    payload = msg.payload
-
-    encoded = schema.encode(payload)
-
-    return encoded
+    return json.dumps(msg.payload).encode("utf-8")

--- a/sentry_streams/sentry_streams/pipeline/msg_parser.py
+++ b/sentry_streams/sentry_streams/pipeline/msg_parser.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 from sentry_streams.pipeline.message import Message
@@ -7,7 +8,7 @@ from sentry_streams.pipeline.message import Message
 # Pass these into Parser() and Serializer() steps, see examples/
 
 
-def msg_parser(msg: Message[bytes]) -> Message[Any]:
+def msg_parser(msg: Message[bytes]) -> Any:
     codec = msg.schema
     payload = msg.payload
 
@@ -17,15 +18,10 @@ def msg_parser(msg: Message[bytes]) -> Message[Any]:
 
     decoded = codec.decode(payload, True)
 
-    return Message(decoded, codec)
+    return decoded
 
 
 def msg_serializer(msg: Message[Any]) -> bytes:
-    codec = msg.schema
     payload = msg.payload
 
-    assert codec is not None
-
-    encoded = codec.encode(payload, False)
-
-    return encoded
+    return json.dumps(payload).encode("utf-8")

--- a/sentry_streams/sentry_streams/pipeline/msg_parser.py
+++ b/sentry_streams/sentry_streams/pipeline/msg_parser.py
@@ -1,0 +1,44 @@
+from json import JSONDecodeError, dumps, loads
+from typing import Any, Mapping, cast
+
+# # # Only supports JSON now
+# class Serializer(ABC):
+
+#     @abstractmethod
+#     def serialize(self, msg: Mapping[str, Any]) -> Any:
+#         raise NotImplementedError
+
+
+# # class JSONSerializer(Serializer):
+
+#     def __init__(self) -> None:
+#         pass
+
+#     def serialize(self, msg: Mapping[str, Any]) -> Any:
+#         return dumps(msg)
+
+
+def json_parser(msg: bytes) -> Mapping[str, Any]:
+    try:
+        parsed = loads(msg)
+    except JSONDecodeError:
+        return {"type": "invalid"}
+
+    return cast(Mapping[str, Any], parsed)
+
+
+def json_serializer(msg: Mapping[str, Any]) -> Any:
+    return dumps(msg)
+
+
+# class ValidatingParser:
+#     """
+#     Handles both deserialization and schema validation
+#     of a message payload
+#     """
+
+#     def __init__(self, deserializer: Deserializer):
+#         self.de = deserializer
+
+#     def parse(self, msg: bytes) -> Mapping[str, Any]:
+#         return self.de.deserialize(msg)

--- a/sentry_streams/sentry_streams/pipeline/msg_parser.py
+++ b/sentry_streams/sentry_streams/pipeline/msg_parser.py
@@ -5,7 +5,7 @@ from sentry_streams.pipeline.message import Message
 
 # TODO: Push the following to docs
 # Standard message decoders and encoders live here
-# Pass these into Parser() and Serializer() steps, see examples/
+# These are used in the defintions of Parser() and Serializer() steps, see chain/
 
 
 def msg_parser(msg: Message[bytes]) -> Any:

--- a/sentry_streams/sentry_streams/pipeline/msg_parser.py
+++ b/sentry_streams/sentry_streams/pipeline/msg_parser.py
@@ -8,7 +8,7 @@ def json_parser(msg: Message[bytes]) -> Message[Any]:
     schema = msg.schema
     assert (
         schema is not None
-    )  # Message cannot be deserialized without a schema, this should be automatically inferred by stream sources
+    )  # Message cannot be deserialized without a schema, it is automatically inferred from the stream source
 
     payload = msg.payload
 

--- a/sentry_streams/sentry_streams/pipeline/msg_parser.py
+++ b/sentry_streams/sentry_streams/pipeline/msg_parser.py
@@ -1,22 +1,6 @@
 from json import JSONDecodeError, dumps, loads
 from typing import Any, Mapping, cast
 
-# # # Only supports JSON now
-# class Serializer(ABC):
-
-#     @abstractmethod
-#     def serialize(self, msg: Mapping[str, Any]) -> Any:
-#         raise NotImplementedError
-
-
-# # class JSONSerializer(Serializer):
-
-#     def __init__(self) -> None:
-#         pass
-
-#     def serialize(self, msg: Mapping[str, Any]) -> Any:
-#         return dumps(msg)
-
 
 def json_parser(msg: bytes) -> Mapping[str, Any]:
     try:
@@ -29,16 +13,3 @@ def json_parser(msg: bytes) -> Mapping[str, Any]:
 
 def json_serializer(msg: Mapping[str, Any]) -> Any:
     return dumps(msg)
-
-
-# class ValidatingParser:
-#     """
-#     Handles both deserialization and schema validation
-#     of a message payload
-#     """
-
-#     def __init__(self, deserializer: Deserializer):
-#         self.de = deserializer
-
-#     def parse(self, msg: bytes) -> Mapping[str, Any]:
-#         return self.de.deserialize(msg)

--- a/sentry_streams/sentry_streams/pipeline/msg_parser.py
+++ b/sentry_streams/sentry_streams/pipeline/msg_parser.py
@@ -2,8 +2,9 @@ from typing import Any
 
 from sentry_streams.pipeline.message import Message
 
+# TODO: Push the following to docs
 # Standard message decoders and encoders live here
-# Choose between transports like JSON, protobuf
+# Pass these into Parser() and Serializer() steps, see examples/
 
 
 def msg_parser(msg: Message[bytes]) -> Message[Any]:

--- a/sentry_streams/sentry_streams/pipeline/msg_parser.py
+++ b/sentry_streams/sentry_streams/pipeline/msg_parser.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 from sentry_streams.pipeline.message import Message
@@ -7,18 +6,25 @@ from sentry_streams.pipeline.message import Message
 # Choose between transports like JSON, protobuf
 
 
-def json_parser(msg: Message[bytes]) -> Message[Any]:
-    schema = msg.schema
-    assert (
-        schema is not None
-    )  # Message cannot be deserialized without a schema, it is automatically inferred from the stream source
-
+def msg_parser(msg: Message[bytes]) -> Message[Any]:
+    codec = msg.schema
     payload = msg.payload
 
-    decoded = schema.decode(payload, True)
+    assert (
+        codec is not None
+    )  # Message cannot be deserialized without a schema, it is automatically inferred from the stream source
 
-    return Message(decoded, schema)
+    decoded = codec.decode(payload, True)
+
+    return Message(decoded, codec)
 
 
-def json_serializer(msg: Message[Any]) -> bytes:
-    return json.dumps(msg.payload).encode("utf-8")
+def msg_serializer(msg: Message[Any]) -> bytes:
+    codec = msg.schema
+    payload = msg.payload
+
+    assert codec is not None
+
+    encoded = codec.encode(payload, False)
+
+    return encoded

--- a/sentry_streams/sentry_streams/pipeline/pipeline.py
+++ b/sentry_streams/sentry_streams/pipeline/pipeline.py
@@ -14,6 +14,7 @@ from typing import (
     Optional,
     Sequence,
     Set,
+    Tuple,
     TypeVar,
     Union,
     cast,
@@ -165,6 +166,7 @@ class StreamSource(Source):
     """
 
     stream_name: str
+    header_filter: Optional[Tuple[str, bytes]] = None
     step_type: StepType = StepType.SOURCE
 
     def __post_init__(self) -> None:

--- a/sentry_streams/tests/adapters/arroyo/test_consumer.py
+++ b/sentry_streams/tests/adapters/arroyo/test_consumer.py
@@ -9,6 +9,7 @@ from unittest.mock import call
 from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.backends.local.backend import LocalBroker
 from arroyo.types import Commit, Partition, Topic
+from sentry_kafka_schemas import get_codec
 from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 
 from sentry_streams.adapters.arroyo.consumer import (
@@ -34,6 +35,8 @@ from sentry_streams.pipeline.pipeline import (
 )
 from tests.adapters.arroyo.message_helpers import make_kafka_msg
 
+SCHEMA = get_codec("ingest-metrics")
+
 
 def test_single_route(
     broker: LocalBroker[KafkaPayload],
@@ -47,7 +50,7 @@ def test_single_route(
     """
     empty_route = Route(source="source1", waypoints=[])
 
-    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics")
+    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics", schema=SCHEMA)
     consumer.add_step(
         MapStep(
             route=empty_route,
@@ -127,7 +130,7 @@ def test_broadcast(
     contain a Broadcast.
     """
 
-    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics")
+    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics", schema=SCHEMA)
     consumer.add_step(
         MapStep(
             route=Route(source="source1", waypoints=[]),
@@ -215,7 +218,7 @@ def test_multiple_routes(
     contain branching routes.
     """
 
-    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics")
+    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics", schema=SCHEMA)
     consumer.add_step(
         MapStep(
             route=Route(source="source1", waypoints=[]),
@@ -308,7 +311,7 @@ def test_standard_reduce(
     and offset management strategy
     """
 
-    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics")
+    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics", schema=SCHEMA)
     consumer.add_step(
         MapStep(
             route=Route(source="source1", waypoints=[]),
@@ -469,7 +472,7 @@ def test_reduce_with_gap(
     and offset management strategy
     """
 
-    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics")
+    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics", schema=SCHEMA)
     consumer.add_step(
         MapStep(
             route=Route(source="source1", waypoints=[]),

--- a/sentry_streams/tests/adapters/arroyo/test_consumer.py
+++ b/sentry_streams/tests/adapters/arroyo/test_consumer.py
@@ -1,4 +1,6 @@
+import json
 import time
+from copy import deepcopy
 from datetime import timedelta
 from typing import Any, cast
 from unittest import mock
@@ -7,6 +9,7 @@ from unittest.mock import call
 from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.backends.local.backend import LocalBroker
 from arroyo.types import Commit, Partition, Topic
+from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 
 from sentry_streams.adapters.arroyo.consumer import (
     ArroyoConsumer,
@@ -32,14 +35,19 @@ from sentry_streams.pipeline.pipeline import (
 from tests.adapters.arroyo.message_helpers import make_kafka_msg
 
 
-def test_single_route(broker: LocalBroker[KafkaPayload], pipeline: Pipeline) -> None:
+def test_single_route(
+    broker: LocalBroker[KafkaPayload],
+    pipeline: Pipeline,
+    metric: IngestMetric,
+    transformed_metric: IngestMetric,
+) -> None:
     """
     Test the creation of an Arroyo Consumer from a number of
     pipeline steps.
     """
     empty_route = Route(source="source1", waypoints=[])
 
-    consumer = ArroyoConsumer(source="source1")
+    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics")
     consumer.add_step(
         MapStep(
             route=empty_route,
@@ -59,6 +67,12 @@ def test_single_route(broker: LocalBroker[KafkaPayload], pipeline: Pipeline) -> 
         )
     )
     consumer.add_step(
+        MapStep(
+            route=empty_route,
+            pipeline_step=cast(Map, pipeline.steps["serializer"]),
+        )
+    )
+    consumer.add_step(
         StreamSinkStep(
             route=empty_route,
             producer=broker.get_producer(),
@@ -68,44 +82,52 @@ def test_single_route(broker: LocalBroker[KafkaPayload], pipeline: Pipeline) -> 
 
     factory = ArroyoStreamingFactory(consumer)
     commit = mock.Mock(spec=Commit)
-    strategy = factory.create_with_partitions(commit, {Partition(Topic("events"), 0): 0})
+    strategy = factory.create_with_partitions(commit, {Partition(Topic("ingest-metrics"), 0): 0})
 
-    strategy.submit(make_kafka_msg("go_ahead", "events", 0))
+    counter_metric = deepcopy(metric)
+    counter_metric["type"] = "c"
+
+    strategy.submit(make_kafka_msg(json.dumps(metric), "ingest-metrics", 0))
     strategy.poll()
-    strategy.submit(make_kafka_msg("do_not_go_ahead", "events", 2))
+    strategy.submit(make_kafka_msg(json.dumps(counter_metric), "ingest-metrics", 2))
     strategy.poll()
-    strategy.submit(make_kafka_msg("go_ahead", "events", 3))
+    strategy.submit(make_kafka_msg(json.dumps(metric), "ingest-metrics", 3))
     strategy.poll()
 
     topic = Topic("transformed-events")
     msg1 = broker.consume(Partition(topic, 0), 0)
-    assert msg1 is not None and msg1.payload.value == "go_ahead_mapped".encode("utf-8")
+    assert msg1 is not None and msg1.payload.value == json.dumps(transformed_metric).encode("utf-8")
     msg2 = broker.consume(Partition(topic, 0), 1)
-    assert msg2 is not None and msg2.payload.value == "go_ahead_mapped".encode("utf-8")
+    assert msg2 is not None and msg2.payload.value == json.dumps(transformed_metric).encode("utf-8")
     assert broker.consume(Partition(topic, 0), 2) is None
 
     commit.assert_has_calls(
         [
             call({}),
-            call({Partition(Topic("events"), 0): 1}),
+            call({Partition(Topic("ingest-metrics"), 0): 1}),
             call({}),
-            call({Partition(Topic("events"), 0): 3}),
+            call({Partition(Topic("ingest-metrics"), 0): 3}),
             call({}),
             call({}),
             call({}),
-            call({Partition(Topic("events"), 0): 4}),
+            call({Partition(Topic("ingest-metrics"), 0): 4}),
             call({}),
         ],
     )
 
 
-def test_broadcast(broker: LocalBroker[KafkaPayload], broadcast_pipeline: Pipeline) -> None:
+def test_broadcast(
+    broker: LocalBroker[KafkaPayload],
+    broadcast_pipeline: Pipeline,
+    metric: IngestMetric,
+    transformed_metric: IngestMetric,
+) -> None:
     """
     Test the creation of an Arroyo Consumer from pipeline steps which
     contain a Broadcast.
     """
 
-    consumer = ArroyoConsumer(source="source1")
+    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics")
     consumer.add_step(
         MapStep(
             route=Route(source="source1", waypoints=[]),
@@ -131,6 +153,18 @@ def test_broadcast(broker: LocalBroker[KafkaPayload], broadcast_pipeline: Pipeli
         )
     )
     consumer.add_step(
+        MapStep(
+            route=Route(source="source1", waypoints=["even_branch"]),
+            pipeline_step=cast(Map, broadcast_pipeline.steps["serializer"]),
+        )
+    )
+    consumer.add_step(
+        MapStep(
+            route=Route(source="source1", waypoints=["odd_branch"]),
+            pipeline_step=cast(Map, broadcast_pipeline.steps["serializer2"]),
+        )
+    )
+    consumer.add_step(
         StreamSinkStep(
             route=Route(source="source1", waypoints=["even_branch"]),
             producer=broker.get_producer(),
@@ -147,33 +181,41 @@ def test_broadcast(broker: LocalBroker[KafkaPayload], broadcast_pipeline: Pipeli
 
     factory = ArroyoStreamingFactory(consumer)
     commit = mock.Mock(spec=Commit)
-    strategy = factory.create_with_partitions(commit, {Partition(Topic("events"), 0): 0})
+    strategy = factory.create_with_partitions(commit, {Partition(Topic("ingest-metrics"), 0): 0})
 
-    strategy.submit(make_kafka_msg("go_ahead", "events", 0))
+    strategy.submit(make_kafka_msg(json.dumps(metric), "ingest-metrics", 0))
     strategy.poll()
-    strategy.submit(make_kafka_msg("do_not_go_ahead", "events", 2))
+    strategy.submit(make_kafka_msg(json.dumps(metric), "ingest-metrics", 2))
     strategy.poll()
-    strategy.submit(make_kafka_msg("go_ahead", "events", 3))
+    strategy.submit(make_kafka_msg(json.dumps(metric), "ingest-metrics", 3))
     strategy.poll()
 
     topics = [Topic("transformed-events"), Topic("transformed-events-2")]
 
     for topic in topics:
         msg1 = broker.consume(Partition(topic, 0), 0)
-        assert msg1 is not None and msg1.payload.value == "go_ahead_mapped".encode("utf-8")
+        assert msg1 is not None and msg1.payload.value == json.dumps(transformed_metric).encode(
+            "utf-8"
+        )
         msg2 = broker.consume(Partition(topic, 0), 1)
-        assert msg2 is not None and msg2.payload.value == "do_not_go_ahead_mapped".encode("utf-8")
+        assert msg2 is not None and msg2.payload.value == json.dumps(transformed_metric).encode(
+            "utf-8"
+        )
         msg3 = broker.consume(Partition(topic, 0), 2)
-        assert msg3 is not None and msg3.payload.value == "go_ahead_mapped".encode("utf-8")
+        assert msg3 is not None and msg3.payload.value == json.dumps(transformed_metric).encode(
+            "utf-8"
+        )
 
 
-def test_multiple_routes(broker: LocalBroker[KafkaPayload], router_pipeline: Pipeline) -> None:
+def test_multiple_routes(
+    broker: LocalBroker[KafkaPayload], router_pipeline: Pipeline, metric: IngestMetric
+) -> None:
     """
     Test the creation of an Arroyo Consumer from pipeline steps which
     contain branching routes.
     """
 
-    consumer = ArroyoConsumer(source="source1")
+    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics")
     consumer.add_step(
         MapStep(
             route=Route(source="source1", waypoints=[]),
@@ -187,27 +229,27 @@ def test_multiple_routes(broker: LocalBroker[KafkaPayload], router_pipeline: Pip
         )
     )
     consumer.add_step(
-        FilterStep(
-            route=Route(source="source1", waypoints=["even_branch"]),
-            pipeline_step=cast(Filter, router_pipeline.steps["myfilter"]),
+        MapStep(
+            route=Route(source="source1", waypoints=["set_branch"]),
+            pipeline_step=cast(Map, router_pipeline.steps["serializer"]),
         )
     )
     consumer.add_step(
         MapStep(
-            route=Route(source="source1", waypoints=["odd_branch"]),
-            pipeline_step=cast(Map, router_pipeline.steps["mymap"]),
+            route=Route(source="source1", waypoints=["not_set_branch"]),
+            pipeline_step=cast(Map, router_pipeline.steps["serializer2"]),
         )
     )
     consumer.add_step(
         StreamSinkStep(
-            route=Route(source="source1", waypoints=["even_branch"]),
+            route=Route(source="source1", waypoints=["set_branch"]),
             producer=broker.get_producer(),
             topic_name="transformed-events",
         )
     )
     consumer.add_step(
         StreamSinkStep(
-            route=Route(source="source1", waypoints=["odd_branch"]),
+            route=Route(source="source1", waypoints=["not_set_branch"]),
             producer=broker.get_producer(),
             topic_name="transformed-events-2",
         )
@@ -215,50 +257,58 @@ def test_multiple_routes(broker: LocalBroker[KafkaPayload], router_pipeline: Pip
 
     factory = ArroyoStreamingFactory(consumer)
     commit = mock.Mock(spec=Commit)
-    strategy = factory.create_with_partitions(commit, {Partition(Topic("events"), 0): 0})
+    strategy = factory.create_with_partitions(commit, {Partition(Topic("ingest-metrics"), 0): 0})
 
-    strategy.submit(make_kafka_msg("go_ahead", "events", 0))
+    counter_metric = deepcopy(metric)
+    counter_metric["type"] = "c"
+
+    strategy.submit(make_kafka_msg(json.dumps(metric), "ingest-metrics", 0))
     strategy.poll()
-    strategy.submit(make_kafka_msg("do_not_go_ahead", "events", 2))
+    strategy.submit(make_kafka_msg(json.dumps(counter_metric), "ingest-metrics", 2))
     strategy.poll()
-    strategy.submit(make_kafka_msg("go_ahead", "events", 3))
+    strategy.submit(make_kafka_msg(json.dumps(metric), "ingest-metrics", 3))
     strategy.poll()
 
-    topic = Topic("transformed-events")
-    topic2 = Topic("transformed-events-2")
+    topic = Topic("transformed-events")  # for set messages
+    topic2 = Topic("transformed-events-2")  # for non-set messages
 
     msg1 = broker.consume(Partition(topic, 0), 0)
-    assert msg1 is not None and msg1.payload.value == "go_ahead".encode("utf-8")
+    assert msg1 is not None and msg1.payload.value == json.dumps(metric).encode("utf-8")
     msg2 = broker.consume(Partition(topic, 0), 1)
-    assert msg2 is not None and msg2.payload.value == "go_ahead".encode("utf-8")
+    assert msg2 is not None and msg2.payload.value == json.dumps(metric).encode("utf-8")
     msg3 = broker.consume(Partition(topic2, 0), 0)
-    assert msg3 is not None and msg3.payload.value == "do_not_go_ahead_mapped".encode("utf-8")
+    assert msg3 is not None and msg3.payload.value == json.dumps(counter_metric).encode("utf-8")
 
     commit.assert_has_calls(
         [
             call({}),
-            call({Partition(topic=Topic(name="events"), index=0): 1}),
+            call({Partition(topic=Topic(name="ingest-metrics"), index=0): 1}),
             call({}),
             call({}),
             call({}),
             call({}),
-            call({Partition(topic=Topic(name="events"), index=0): 3}),
+            call({Partition(topic=Topic(name="ingest-metrics"), index=0): 3}),
             call({}),
             call({}),
-            call({Partition(topic=Topic(name="events"), index=0): 4}),
+            call({Partition(topic=Topic(name="ingest-metrics"), index=0): 4}),
             call({}),
             call({}),
         ],
     )
 
 
-def test_standard_reduce(broker: LocalBroker[KafkaPayload], reduce_pipeline: Pipeline) -> None:
+def test_standard_reduce(
+    broker: LocalBroker[KafkaPayload],
+    reduce_pipeline: Pipeline,
+    metric: IngestMetric,
+    transformed_metric: IngestMetric,
+) -> None:
     """
     Test a full "loop" of the sliding window algorithm. Checks for correct results, timestamps,
     and offset management strategy
     """
 
-    consumer = ArroyoConsumer(source="source1")
+    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics")
     consumer.add_step(
         MapStep(
             route=Route(source="source1", waypoints=[]),
@@ -278,6 +328,12 @@ def test_standard_reduce(broker: LocalBroker[KafkaPayload], reduce_pipeline: Pip
         )
     )
     consumer.add_step(
+        MapStep(
+            route=Route(source="source1", waypoints=[]),
+            pipeline_step=cast(Map, reduce_pipeline.steps["serializer"]),
+        )
+    )
+    consumer.add_step(
         StreamSinkStep(
             route=Route(source="source1", waypoints=[]),
             producer=broker.get_producer(),
@@ -287,33 +343,28 @@ def test_standard_reduce(broker: LocalBroker[KafkaPayload], reduce_pipeline: Pip
 
     factory = ArroyoStreamingFactory(consumer)
     commit = mock.Mock(spec=Commit)
-    strategy = factory.create_with_partitions(commit, {Partition(Topic("logical-events"), 0): 0})
+    strategy = factory.create_with_partitions(commit, {Partition(Topic("ingest-metrics"), 0): 0})
 
     cur_time = time.time()
 
     # 6 messages
     # Accumulators: [0,1] [2,3] [4,5] [6,7] [8,9]
     for i in range(6):
-        msg = f"msg{i}"
         with mock.patch("time.time", return_value=cur_time + 2 * i):
-            strategy.submit(make_kafka_msg(msg, "logical-events", i))
+            strategy.submit(make_kafka_msg(json.dumps(metric), "ingest-metrics", i))
 
     # Last submit was at T+10, which means we've only flushed the first 3 windows
+    three_msgs = json.dumps([transformed_metric for _ in range(3)])
     topic = Topic("transformed-events")
     msg1 = broker.consume(Partition(topic, 0), 0)
-    assert msg1 is not None and msg1.payload.value == "msg0_mappedmsg1_mappedmsg2_mapped".encode(
-        "utf-8"
-    )
+
+    assert msg1 is not None and msg1.payload.value == three_msgs.encode("utf-8")
 
     msg2 = broker.consume(Partition(topic, 0), 1)
-    assert msg2 is not None and msg2.payload.value == "msg1_mappedmsg2_mappedmsg3_mapped".encode(
-        "utf-8"
-    )
+    assert msg2 is not None and msg2.payload.value == three_msgs.encode("utf-8")
 
     msg3 = broker.consume(Partition(topic, 0), 2)
-    assert msg3 is not None and msg3.payload.value == "msg2_mappedmsg3_mappedmsg4_mapped".encode(
-        "utf-8"
-    )
+    assert msg3 is not None and msg3.payload.value == three_msgs.encode("utf-8")
 
     # Poll 3 times now for the remaining 3 windows to flush
     # This time, there are no more submit() calls for making progress
@@ -322,26 +373,25 @@ def test_standard_reduce(broker: LocalBroker[KafkaPayload], reduce_pipeline: Pip
             strategy.poll()
 
     msg4 = broker.consume(Partition(topic, 0), 3)
-    assert msg4 is not None and msg4.payload.value == "msg3_mappedmsg4_mappedmsg5_mapped".encode(
-        "utf-8"
-    )
+    assert msg4 is not None and msg4.payload.value == three_msgs.encode("utf-8")
 
+    two_msgs = json.dumps([transformed_metric for _ in range(2)])
     msg5 = broker.consume(Partition(topic, 0), 4)
-    assert msg5 is not None and msg5.payload.value == "msg4_mappedmsg5_mapped".encode("utf-8")
+    assert msg5 is not None and msg5.payload.value == two_msgs.encode("utf-8")
 
+    one_msg = json.dumps([transformed_metric])
     msg6 = broker.consume(Partition(topic, 0), 5)
-    assert msg6 is not None and msg6.payload.value == "msg5_mapped".encode("utf-8")
+    assert msg6 is not None and msg6.payload.value == one_msg.encode("utf-8")
 
     # Up to this point everything is flushed out
 
     # Submit data at T+24, T+26 (data comes in at a gap)
     for i in range(12, 14):
-        msg = f"msg{i}"
         with mock.patch("time.time", return_value=cur_time + 2 * i):
-            strategy.submit(make_kafka_msg(msg, "logical-events", i))
+            strategy.submit(make_kafka_msg(json.dumps(metric), "ingest-metrics", i))
 
     msg12 = broker.consume(Partition(topic, 0), 6)
-    assert msg12 is not None and msg12.payload.value == "msg12_mapped".encode("utf-8")
+    assert msg12 is not None and msg12.payload.value == one_msg.encode("utf-8")
 
     msg13 = broker.consume(Partition(topic, 0), 7)
     assert msg13 is None
@@ -350,7 +400,7 @@ def test_standard_reduce(broker: LocalBroker[KafkaPayload], reduce_pipeline: Pip
         strategy.poll()
 
     msg13 = broker.consume(Partition(topic, 0), 7)
-    assert msg13 is not None and msg13.payload.value == "msg12_mappedmsg13_mapped".encode("utf-8")
+    assert msg13 is not None and msg13.payload.value == two_msgs.encode("utf-8")
 
     msg14 = broker.consume(Partition(topic, 0), 8)
     assert msg14 is None
@@ -359,13 +409,13 @@ def test_standard_reduce(broker: LocalBroker[KafkaPayload], reduce_pipeline: Pip
         strategy.poll()
 
     msg14 = broker.consume(Partition(topic, 0), 8)
-    assert msg14 is not None and msg14.payload.value == "msg12_mappedmsg13_mapped".encode("utf-8")
+    assert msg14 is not None and msg14.payload.value == two_msgs.encode("utf-8")
 
     with mock.patch("time.time", return_value=cur_time + 2 * 16):
         strategy.poll()
 
     msg15 = broker.consume(Partition(topic, 0), 9)
-    assert msg15 is not None and msg15.payload.value == "msg13_mapped".encode("utf-8")
+    assert msg15 is not None and msg15.payload.value == one_msg.encode("utf-8")
 
     with mock.patch("time.time", return_value=cur_time + 2 * 17):
         strategy.poll()
@@ -377,30 +427,30 @@ def test_standard_reduce(broker: LocalBroker[KafkaPayload], reduce_pipeline: Pip
     commit.assert_has_calls(
         [
             call({}),
-            call({Partition(topic=Topic(name="logical-events"), index=0): 1}),
+            call({Partition(topic=Topic(name="ingest-metrics"), index=0): 1}),
             call({}),
-            call({Partition(topic=Topic(name="logical-events"), index=0): 2}),
+            call({Partition(topic=Topic(name="ingest-metrics"), index=0): 2}),
             call({}),
-            call({Partition(topic=Topic(name="logical-events"), index=0): 3}),
+            call({Partition(topic=Topic(name="ingest-metrics"), index=0): 3}),
             call({}),
-            call({Partition(topic=Topic(name="logical-events"), index=0): 4}),
-            call({}),
-            call({}),
-            call({Partition(topic=Topic(name="logical-events"), index=0): 5}),
+            call({Partition(topic=Topic(name="ingest-metrics"), index=0): 4}),
             call({}),
             call({}),
-            call({Partition(topic=Topic(name="logical-events"), index=0): 6}),
+            call({Partition(topic=Topic(name="ingest-metrics"), index=0): 5}),
             call({}),
             call({}),
+            call({Partition(topic=Topic(name="ingest-metrics"), index=0): 6}),
             call({}),
             call({}),
             call({}),
             call({}),
             call({}),
-            call({Partition(topic=Topic(name="logical-events"), index=0): 13}),
             call({}),
             call({}),
-            call({Partition(topic=Topic(name="logical-events"), index=0): 14}),
+            call({Partition(topic=Topic(name="ingest-metrics"), index=0): 13}),
+            call({}),
+            call({}),
+            call({Partition(topic=Topic(name="ingest-metrics"), index=0): 14}),
             call({}),
             call({}),
             call({}),
@@ -408,13 +458,18 @@ def test_standard_reduce(broker: LocalBroker[KafkaPayload], reduce_pipeline: Pip
     )
 
 
-def test_reduce_with_gap(broker: LocalBroker[KafkaPayload], reduce_pipeline: Pipeline) -> None:
+def test_reduce_with_gap(
+    broker: LocalBroker[KafkaPayload],
+    reduce_pipeline: Pipeline,
+    metric: IngestMetric,
+    transformed_metric: IngestMetric,
+) -> None:
     """
     Test a full "loop" of the sliding window algorithm. Checks for correct results, timestamps,
     and offset management strategy
     """
 
-    consumer = ArroyoConsumer(source="source1")
+    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics")
     consumer.add_step(
         MapStep(
             route=Route(source="source1", waypoints=[]),
@@ -434,6 +489,12 @@ def test_reduce_with_gap(broker: LocalBroker[KafkaPayload], reduce_pipeline: Pip
         )
     )
     consumer.add_step(
+        MapStep(
+            route=Route(source="source1", waypoints=[]),
+            pipeline_step=cast(Map, reduce_pipeline.steps["serializer"]),
+        )
+    )
+    consumer.add_step(
         StreamSinkStep(
             route=Route(source="source1", waypoints=[]),
             producer=broker.get_producer(),
@@ -443,34 +504,28 @@ def test_reduce_with_gap(broker: LocalBroker[KafkaPayload], reduce_pipeline: Pip
 
     factory = ArroyoStreamingFactory(consumer)
     commit = mock.Mock(spec=Commit)
-    strategy = factory.create_with_partitions(commit, {Partition(Topic("logical-events"), 0): 0})
+    strategy = factory.create_with_partitions(commit, {Partition(Topic("ingest-metrics"), 0): 0})
 
     cur_time = time.time()
 
     # 6 messages
     # Accumulators: [0,1] [2,3] [4,5] [6,7] [8,9]
     for i in range(6):
-        msg = f"msg{i}"
         with mock.patch("time.time", return_value=cur_time + 2 * i):
-            strategy.submit(make_kafka_msg(msg, "logical-events", i))
+            strategy.submit(make_kafka_msg(json.dumps(metric), "ingest-metrics", i))
 
     # Last submit was at T+10, which means we've only flushed the first 3 windows
 
+    three_msgs = json.dumps([transformed_metric for _ in range(3)])
     topic = Topic("transformed-events")
     msg1 = broker.consume(Partition(topic, 0), 0)
-    assert msg1 is not None and msg1.payload.value == "msg0_mappedmsg1_mappedmsg2_mapped".encode(
-        "utf-8"
-    )
+    assert msg1 is not None and msg1.payload.value == three_msgs.encode("utf-8")
 
     msg2 = broker.consume(Partition(topic, 0), 1)
-    assert msg2 is not None and msg2.payload.value == "msg1_mappedmsg2_mappedmsg3_mapped".encode(
-        "utf-8"
-    )
+    assert msg2 is not None and msg2.payload.value == three_msgs.encode("utf-8")
 
     msg3 = broker.consume(Partition(topic, 0), 2)
-    assert msg3 is not None and msg3.payload.value == "msg2_mappedmsg3_mappedmsg4_mapped".encode(
-        "utf-8"
-    )
+    assert msg3 is not None and msg3.payload.value == three_msgs.encode("utf-8")
 
     # We did not make it past the first 3 windows yet
     msg4 = broker.consume(Partition(topic, 0), 3)
@@ -481,29 +536,29 @@ def test_reduce_with_gap(broker: LocalBroker[KafkaPayload], reduce_pipeline: Pip
         strategy.poll()
 
     msg4 = broker.consume(Partition(topic, 0), 3)
-    assert msg4 is not None and msg4.payload.value == "msg3_mappedmsg4_mappedmsg5_mapped".encode(
-        "utf-8"
-    )
+    assert msg4 is not None and msg4.payload.value == three_msgs.encode("utf-8")
 
+    two_msgs = json.dumps([transformed_metric for _ in range(2)])
     msg5 = broker.consume(Partition(topic, 0), 4)
-    assert msg5 is not None and msg5.payload.value == "msg4_mappedmsg5_mapped".encode("utf-8")
+    assert msg5 is not None and msg5.payload.value == two_msgs.encode("utf-8")
 
+    one_msg = json.dumps([transformed_metric])
     msg6 = broker.consume(Partition(topic, 0), 5)
-    assert msg6 is not None and msg6.payload.value == "msg5_mapped".encode("utf-8")
+    assert msg6 is not None and msg6.payload.value == one_msg.encode("utf-8")
 
     commit.assert_has_calls(
         [
             call({}),
-            call({Partition(Topic("logical-events"), 0): 1}),
+            call({Partition(Topic("ingest-metrics"), 0): 1}),
             call({}),
-            call({Partition(Topic("logical-events"), 0): 2}),
+            call({Partition(Topic("ingest-metrics"), 0): 2}),
             call({}),
-            call({Partition(Topic("logical-events"), 0): 3}),
+            call({Partition(Topic("ingest-metrics"), 0): 3}),
             call({}),
-            call({Partition(Topic("logical-events"), 0): 4}),
+            call({Partition(Topic("ingest-metrics"), 0): 4}),
             call({}),
-            call({Partition(Topic("logical-events"), 0): 5}),
+            call({Partition(Topic("ingest-metrics"), 0): 5}),
             call({}),
-            call({Partition(Topic("logical-events"), 0): 6}),
+            call({Partition(Topic("ingest-metrics"), 0): 6}),
         ]
     )

--- a/sentry_streams/tests/adapters/arroyo/test_steps.py
+++ b/sentry_streams/tests/adapters/arroyo/test_steps.py
@@ -1,19 +1,25 @@
+import json
 import time
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Callable
 from unittest import mock
-from unittest.mock import call
+from unittest.mock import ANY, call
 
 from arroyo.backends.abstract import Producer
 from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.processing.strategies.abstract import ProcessingStrategy
 from arroyo.types import (
+    BrokerValue,
     Commit,
     FilteredPayload,
+    Message,
+    Partition,
     Topic,
+    Value,
 )
+from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 
-from sentry_streams.adapters.arroyo.routes import Route
+from sentry_streams.adapters.arroyo.routes import Route, RoutedValue
 from sentry_streams.adapters.arroyo.steps import (
     BroadcastStep,
     FilterStep,
@@ -23,6 +29,7 @@ from sentry_streams.adapters.arroyo.steps import (
     StreamSinkStep,
 )
 from sentry_streams.examples.transformer import TransformerBatch
+from sentry_streams.pipeline.message import Message as StreamsMessage
 from sentry_streams.pipeline.pipeline import (
     Aggregate,
     Branch,
@@ -36,7 +43,7 @@ from sentry_streams.pipeline.window import SlidingWindow
 from tests.adapters.arroyo.message_helpers import make_msg, make_value_msg
 
 
-def test_map_step() -> None:
+def test_map_step(metric: IngestMetric) -> None:
     """
     Send messages for different routes through the Arroyo RunTask strategy
     generate by the pipeline Map step.
@@ -45,16 +52,18 @@ def test_map_step() -> None:
     mapped_route = Route(source="source1", waypoints=["branch1"])
     other_route = Route(source="source1", waypoints=["branch2"])
     pipeline = Pipeline()
-    pipeline_map = Map(name="mymap", ctx=pipeline, inputs=[], function=lambda x: x + "_mapped")
+    pipeline_map = Map(name="mymap", ctx=pipeline, inputs=[], function=lambda msg: msg.payload)
     arroyo_map = MapStep(mapped_route, pipeline_map)
 
     next_strategy = mock.Mock(spec=ProcessingStrategy)
 
     strategy = arroyo_map.build(next_strategy, commit=mock.Mock(spec=Commit))
 
+    test_msg = StreamsMessage(metric, [], time.time(), None)
+
     messages = [
-        make_msg("test_val", mapped_route, 0),
-        make_msg("test_val", other_route, 1),
+        make_msg(test_msg, mapped_route, 0),
+        make_msg(test_msg, other_route, 1),
         make_msg(FilteredPayload(), mapped_route, 3),
     ]
 
@@ -64,11 +73,11 @@ def test_map_step() -> None:
 
     expected_calls = [
         call.submit(
-            make_msg("test_val_mapped", mapped_route, 0),
+            make_msg(test_msg, mapped_route, 0),
         ),
         call.poll(),
         call.submit(
-            make_msg("test_val", other_route, 1),
+            make_msg(test_msg, other_route, 1),
         ),
         call.poll(),
         call.submit(
@@ -80,7 +89,7 @@ def test_map_step() -> None:
     next_strategy.assert_has_calls(expected_calls)
 
 
-def test_filter_step() -> None:
+def test_filter_step(metric: IngestMetric, transformed_metric: IngestMetric) -> None:
     """
     Send messages for different routes through the Arroyo RunTask strategy
     generate by the pipeline Filter step.
@@ -90,17 +99,22 @@ def test_filter_step() -> None:
     pipeline = Pipeline()
 
     pipeline_filter = Filter(
-        name="myfilter", ctx=pipeline, inputs=[], function=lambda x: x == "test_val"
+        name="myfilter",
+        ctx=pipeline,
+        inputs=[],
+        function=lambda msg: msg.payload["name"] != "new_metric",
     )
     arroyo_filter = FilterStep(mapped_route, pipeline_filter)
 
     next_strategy = mock.Mock(spec=ProcessingStrategy)
     strategy = arroyo_filter.build(next_strategy, commit=mock.Mock(spec=Commit))
 
+    msg = StreamsMessage(metric, [], time.time(), None)
+    filtered_msg = StreamsMessage(transformed_metric, [], time.time(), None)
     messages = [
-        make_msg("test_val", mapped_route, 0),
-        make_msg("not_test_val", mapped_route, 1),
-        make_msg("test_val", other_route, 2),
+        make_msg(msg, mapped_route, 0),
+        make_msg(filtered_msg, mapped_route, 1),
+        make_msg(msg, other_route, 2),
         make_msg(FilteredPayload(), mapped_route, 3),
     ]
 
@@ -110,13 +124,13 @@ def test_filter_step() -> None:
 
     expected_calls = [
         call.submit(
-            make_msg("test_val", mapped_route, 0),
+            make_msg(msg, mapped_route, 0),
         ),
         call.poll(),
         call.submit(make_msg(FilteredPayload(), mapped_route, 1)),
         call.poll(),
         call.submit(
-            make_msg("test_val", other_route, 2),
+            make_msg(msg, other_route, 2),
         ),
         call.poll(),
         call.submit(
@@ -128,7 +142,7 @@ def test_filter_step() -> None:
     next_strategy.assert_has_calls(expected_calls)
 
 
-def test_router() -> None:
+def test_router(metric: IngestMetric, transformed_metric: IngestMetric) -> None:
     """
     Verifies the Router step properly updates the waypoints of a RoutedValue message.
     """
@@ -136,8 +150,8 @@ def test_router() -> None:
     other_route = Route(source="source1", waypoints=["other_branch"])
     pipeline = Pipeline()
 
-    def dummy_routing_func(message: str) -> str:
-        return "map" if message == "test_val" else "other"
+    def dummy_routing_func(message: StreamsMessage[IngestMetric]) -> str:
+        return "map" if message.payload["name"] != "new_metric" else "other"
 
     pipeline_router = Router(
         name="myrouter",
@@ -154,10 +168,13 @@ def test_router() -> None:
     next_strategy = mock.Mock(spec=ProcessingStrategy)
     strategy = arroyo_router.build(next_strategy, commit=mock.Mock(spec=Commit))
 
+    msg = StreamsMessage(metric, [], time.time(), None)
+    filtered_msg = StreamsMessage(transformed_metric, [], time.time(), None)
+
     messages = [
-        make_msg("test_val", Route(source="source1", waypoints=[]), 0),
-        make_msg("not_test_val", Route(source="source1", waypoints=[]), 1),
-        make_msg("test_val", Route(source="source1", waypoints=[]), 2),
+        make_msg(msg, Route(source="source1", waypoints=[]), 0),
+        make_msg(filtered_msg, Route(source="source1", waypoints=[]), 1),
+        make_msg(msg, Route(source="source1", waypoints=[]), 2),
         make_msg(FilteredPayload(), Route(source="source1", waypoints=[]), 3),
     ]
 
@@ -167,13 +184,13 @@ def test_router() -> None:
 
     expected_calls = [
         call.submit(
-            make_msg("test_val", mapped_route, 0),
+            make_msg(msg, mapped_route, 0),
         ),
         call.poll(),
-        call.submit(make_msg("not_test_val", other_route, 1)),
+        call.submit(make_msg(filtered_msg, other_route, 1)),
         call.poll(),
         call.submit(
-            make_msg("test_val", mapped_route, 2),
+            make_msg(msg, mapped_route, 2),
         ),
         call.poll(),
         call.submit(
@@ -185,7 +202,7 @@ def test_router() -> None:
     next_strategy.assert_has_calls(expected_calls)
 
 
-def test_broadcast() -> None:
+def test_broadcast(metric: IngestMetric, transformed_metric: IngestMetric) -> None:
     """
     Verifies the Broadcast step properly updates the waypoints the messages it produces.
     """
@@ -207,14 +224,17 @@ def test_broadcast() -> None:
     next_strategy = mock.Mock(spec=ProcessingStrategy)
     strategy = arroyo_broadcast.build(next_strategy, commit=mock.Mock(spec=Commit))
 
+    msg = StreamsMessage(metric, [], time.time(), None)
+    filtered_msg = StreamsMessage(transformed_metric, [], time.time(), None)
+
     messages = [
         make_value_msg(
-            "test_val",
+            msg,
             Route(source="source1", waypoints=[]),
             0,
         ),
         make_value_msg(
-            "not_test_val",
+            filtered_msg,
             Route(source="source1", waypoints=[]),
             1,
         ),
@@ -230,11 +250,11 @@ def test_broadcast() -> None:
         strategy.poll()
 
     expected_calls = [
-        call.submit(make_value_msg("test_val", mapped_route, 0)),
-        call.submit(make_value_msg("test_val", other_route, 0)),
+        call.submit(make_value_msg(msg, mapped_route, 0)),
+        call.submit(make_value_msg(msg, other_route, 0)),
         call.poll(),
-        call.submit(make_value_msg("not_test_val", mapped_route, 1)),
-        call.submit(make_value_msg("not_test_val", other_route, 1)),
+        call.submit(make_value_msg(filtered_msg, mapped_route, 1)),
+        call.submit(make_value_msg(filtered_msg, other_route, 1)),
         call.poll(),
         call.submit(
             make_value_msg(
@@ -249,7 +269,7 @@ def test_broadcast() -> None:
     next_strategy.assert_has_calls(expected_calls)
 
 
-def test_sink() -> None:
+def test_sink(metric: IngestMetric) -> None:
     """
     Sends routed messages through a Sink and verifies that only the
     messages for the specified sink are sent to the producer.
@@ -263,9 +283,12 @@ def test_sink() -> None:
         next_strategy, commit=mock.Mock(spec=Commit)
     )
 
+    # assume this is a serialized msg being produced to Kafka
+    msg = StreamsMessage(json.dumps(metric).encode("utf-8"), [], time.time(), None)
+
     messages = [
-        make_msg("test_val", mapped_route, 0),
-        make_msg("test_val", other_route, 1),
+        make_msg(msg, mapped_route, 0),
+        make_msg(msg, other_route, 1),
         make_msg(FilteredPayload(), mapped_route, 2),
     ]
 
@@ -273,12 +296,10 @@ def test_sink() -> None:
         strategy.submit(message)
         strategy.poll()
 
-    producer.produce.assert_called_with(
-        Topic("test_topic"), KafkaPayload(None, "test_val".encode("utf-8"), [])
-    )
+    producer.produce.assert_called_with(Topic("test_topic"), KafkaPayload(None, msg.payload, []))
 
 
-def test_reduce_step(transformer: Callable[[], TransformerBatch]) -> None:
+def test_reduce_step(transformer: Callable[[], TransformerBatch], metric: IngestMetric) -> None:
     """
     Send messages for different routes through the Arroyo RunTask strategy
     generate by the pipeline Reduce step.
@@ -303,9 +324,10 @@ def test_reduce_step(transformer: Callable[[], TransformerBatch]) -> None:
     next_strategy = mock.Mock(spec=ProcessingStrategy)
     strategy = arroyo_reduce.build(next_strategy, commit=mock.Mock(spec=Commit))
 
+    msg = StreamsMessage(metric, [], ANY, None)
     messages = [
-        make_msg("test_val", mapped_route, 0),
-        make_msg("test_val", other_route, 1),  # wrong route
+        make_msg(msg, mapped_route, 0),
+        make_msg(msg, other_route, 1),
         make_msg(FilteredPayload(), mapped_route, 3),  # to be filtered out
     ]
 
@@ -318,14 +340,45 @@ def test_reduce_step(transformer: Callable[[], TransformerBatch]) -> None:
     with mock.patch("time.time", return_value=cur_time + 8.0):
         strategy.poll()
 
+    new_msg = StreamsMessage(
+        [metric], [], ANY, None
+    )  # since Reduce produces a timestamp based on when the aggregate result is produced, we mock the timestamp
+
+    other_route_msg = Message(
+        BrokerValue(
+            payload=RoutedValue(route=other_route, payload=msg),
+            partition=Partition(Topic("test_topic"), 0),
+            offset=1,
+            timestamp=datetime(2025, 1, 1, 12, 0),
+        ),
+    )
+
+    mapped_msg = Message(
+        Value(
+            payload=RoutedValue(route=mapped_route, payload=new_msg),
+            committable={Partition(Topic("test_topic"), 0): 1},
+            timestamp=None,
+        )
+    )
+
+    filtered_msg = Message(
+        BrokerValue(
+            payload=FilteredPayload(),
+            partition=Partition(Topic("test_topic"), 0),
+            offset=3,
+            timestamp=datetime(2025, 1, 1, 12, 0),
+        ),
+    )
+
     expected_calls = [
         call.poll(),
-        call.submit(make_msg("test_val", other_route, 1)),
+        call.submit(other_route_msg),
         call.poll(),
-        call.submit(make_msg(FilteredPayload(), mapped_route, 3)),
+        call.submit(filtered_msg),
         call.poll(),
-        call.submit(make_value_msg("test_val", mapped_route, 1, include_timestamp=False)),
+        call.submit(mapped_msg),
         call.poll(),
     ]
 
+    next_strategy
     next_strategy.assert_has_calls(expected_calls)

--- a/sentry_streams/tests/pipeline/test_chain.py
+++ b/sentry_streams/tests/pipeline/test_chain.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, cast
 from unittest import mock
 
 import pytest
+from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 
 from sentry_streams.pipeline.chain import (
     Applier,
@@ -56,10 +57,10 @@ def test_broadcast() -> None:
         .broadcast(
             "route_to_all",
             [
-                segment(name="route1")
+                segment(name="route1", msg_type=IngestMetric)
                 .apply("transform2", Map(lambda msg: msg))
                 .sink("myoutput1", "transformed-events-2"),
-                segment(name="route2")
+                segment(name="route2", msg_type=IngestMetric)
                 .apply("transform3", Map(lambda msg: msg))
                 .sink("myoutput2", "transformed-events-3"),
             ],
@@ -117,10 +118,10 @@ def test_router() -> None:
             "route_to_one",
             routing_function=routing_func,
             routes={
-                Routes.ROUTE1: segment(name="route1")
+                Routes.ROUTE1: segment(name="route1", msg_type=IngestMetric)
                 .apply("transform2", Map(lambda msg: msg))
                 .sink("myoutput1", "transformed-events-2"),
-                Routes.ROUTE2: segment(name="route2")
+                Routes.ROUTE2: segment(name="route2", msg_type=IngestMetric)
                 .apply("transform3", Map(lambda msg: msg))
                 .sink("myoutput2", "transformed-events-3"),
             },

--- a/sentry_streams/tests/test_runner.py
+++ b/sentry_streams/tests/test_runner.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import Any
 
 import pytest
+from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 
 from sentry_streams.adapters.loader import load_adapter
 from sentry_streams.adapters.stream_adapter import PipelineConfig, RuntimeTranslator
@@ -21,22 +22,22 @@ class RouterBranch(Enum):
 @pytest.fixture
 def create_pipeline() -> Pipeline:
     broadcast_branch_1 = (
-        segment("branch1")
+        segment("branch1", IngestMetric)
         .apply("map2", Map(function=lambda x: x))
         .route(
             "router1",
             routing_function=lambda x: RouterBranch.BRANCH1,
             routes={
-                RouterBranch.BRANCH1: segment("map4_segment").apply(
+                RouterBranch.BRANCH1: segment("map4_segment", IngestMetric).apply(
                     "map4", Map(function=lambda x: x)
                 ),
-                RouterBranch.BRANCH2: segment("map5_segment").apply(
+                RouterBranch.BRANCH2: segment("map5_segment", IngestMetric).apply(
                     "map5", Map(function=lambda x: x)
                 ),
             },
         )
     )
-    broadcast_branch_2 = segment("branch2").apply("map3", Map(function=lambda x: x))
+    broadcast_branch_2 = segment("branch2", IngestMetric).apply("map3", Map(function=lambda x: x))
 
     test_pipeline = (
         streaming_source("source1", stream_name="foo")

--- a/sentry_streams/uv.lock
+++ b/sentry_streams/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11"
 
 [[package]]
@@ -147,12 +146,71 @@ wheels = [
 ]
 
 [[package]]
+name = "fastjsonschema"
+version = "2.21.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/50/4b769ce1ac4071a1ef6d86b1a3fb56cdc3a37615e8c5519e1af96cdac366/fastjsonschema-2.21.1.tar.gz", hash = "sha256:794d4f0a58f848961ba16af7b9c85a3e88cd360df008c59aac6fc5ae9323b5d4", size = 373939 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/2b/0817a2b257fe88725c25589d89aec060581aabf668707a8d03b2e9e0cb2a/fastjsonschema-2.21.1-py3-none-any.whl", hash = "sha256:c9e5b7e908310918cf494a434eeb31384dd84a98b57a30bcb1f535015b554667", size = 23924 },
+]
+
+[[package]]
 name = "filelock"
 version = "3.18.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215 },
+]
+
+[[package]]
+name = "grpc-stubs"
+version = "1.53.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/8d/14c6b8c2fa5d82ffe96aed53b1c38e2a9fb6a57c5836966545f3080e5adc/grpc-stubs-1.53.0.5.tar.gz", hash = "sha256:3e1b642775cbc3e0c6332cfcedfccb022176db87e518757bef3a1241397be406", size = 14259 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/86/147d2ccaf9b4b81407734b9abc1152aff39836e8e05be3bf069f9374c021/grpc_stubs-1.53.0.5-py3-none-any.whl", hash = "sha256:04183fb65a1b166a1febb9627e3d9647d3926ccc2dfe049fe7b6af243428dbe1", size = 16497 },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.71.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/95/aa11fc09a85d91fbc7dd405dcb2a1e0256989d67bf89fa65ae24b3ba105a/grpcio-1.71.0.tar.gz", hash = "sha256:2b85f7820475ad3edec209d3d89a7909ada16caab05d3f2e08a7e8ae3200a55c", size = 12549828 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/04/a085f3ad4133426f6da8c1becf0749872a49feb625a407a2e864ded3fb12/grpcio-1.71.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:d6aa986318c36508dc1d5001a3ff169a15b99b9f96ef5e98e13522c506b37eef", size = 5210453 },
+    { url = "https://files.pythonhosted.org/packages/b4/d5/0bc53ed33ba458de95020970e2c22aa8027b26cc84f98bea7fcad5d695d1/grpcio-1.71.0-cp311-cp311-macosx_10_14_universal2.whl", hash = "sha256:d2c170247315f2d7e5798a22358e982ad6eeb68fa20cf7a820bb74c11f0736e7", size = 11347567 },
+    { url = "https://files.pythonhosted.org/packages/e3/6d/ce334f7e7a58572335ccd61154d808fe681a4c5e951f8a1ff68f5a6e47ce/grpcio-1.71.0-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:e6f83a583ed0a5b08c5bc7a3fe860bb3c2eac1f03f1f63e0bc2091325605d2b7", size = 5696067 },
+    { url = "https://files.pythonhosted.org/packages/05/4a/80befd0b8b1dc2b9ac5337e57473354d81be938f87132e147c4a24a581bd/grpcio-1.71.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4be74ddeeb92cc87190e0e376dbc8fc7736dbb6d3d454f2fa1f5be1dee26b9d7", size = 6348377 },
+    { url = "https://files.pythonhosted.org/packages/c7/67/cbd63c485051eb78663355d9efd1b896cfb50d4a220581ec2cb9a15cd750/grpcio-1.71.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4dd0dfbe4d5eb1fcfec9490ca13f82b089a309dc3678e2edabc144051270a66e", size = 5940407 },
+    { url = "https://files.pythonhosted.org/packages/98/4b/7a11aa4326d7faa499f764eaf8a9b5a0eb054ce0988ee7ca34897c2b02ae/grpcio-1.71.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a2242d6950dc892afdf9e951ed7ff89473aaf744b7d5727ad56bdaace363722b", size = 6030915 },
+    { url = "https://files.pythonhosted.org/packages/eb/a2/cdae2d0e458b475213a011078b0090f7a1d87f9a68c678b76f6af7c6ac8c/grpcio-1.71.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:0fa05ee31a20456b13ae49ad2e5d585265f71dd19fbd9ef983c28f926d45d0a7", size = 6648324 },
+    { url = "https://files.pythonhosted.org/packages/27/df/f345c8daaa8d8574ce9869f9b36ca220c8845923eb3087e8f317eabfc2a8/grpcio-1.71.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3d081e859fb1ebe176de33fc3adb26c7d46b8812f906042705346b314bde32c3", size = 6197839 },
+    { url = "https://files.pythonhosted.org/packages/f2/2c/cd488dc52a1d0ae1bad88b0d203bc302efbb88b82691039a6d85241c5781/grpcio-1.71.0-cp311-cp311-win32.whl", hash = "sha256:d6de81c9c00c8a23047136b11794b3584cdc1460ed7cbc10eada50614baa1444", size = 3619978 },
+    { url = "https://files.pythonhosted.org/packages/ee/3f/cf92e7e62ccb8dbdf977499547dfc27133124d6467d3a7d23775bcecb0f9/grpcio-1.71.0-cp311-cp311-win_amd64.whl", hash = "sha256:24e867651fc67717b6f896d5f0cac0ec863a8b5fb7d6441c2ab428f52c651c6b", size = 4282279 },
+    { url = "https://files.pythonhosted.org/packages/4c/83/bd4b6a9ba07825bd19c711d8b25874cd5de72c2a3fbf635c3c344ae65bd2/grpcio-1.71.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:0ff35c8d807c1c7531d3002be03221ff9ae15712b53ab46e2a0b4bb271f38537", size = 5184101 },
+    { url = "https://files.pythonhosted.org/packages/31/ea/2e0d90c0853568bf714693447f5c73272ea95ee8dad107807fde740e595d/grpcio-1.71.0-cp312-cp312-macosx_10_14_universal2.whl", hash = "sha256:b78a99cd1ece4be92ab7c07765a0b038194ded2e0a26fd654591ee136088d8d7", size = 11310927 },
+    { url = "https://files.pythonhosted.org/packages/ac/bc/07a3fd8af80467390af491d7dc66882db43884128cdb3cc8524915e0023c/grpcio-1.71.0-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:dc1a1231ed23caac1de9f943d031f1bc38d0f69d2a3b243ea0d664fc1fbd7fec", size = 5654280 },
+    { url = "https://files.pythonhosted.org/packages/16/af/21f22ea3eed3d0538b6ef7889fce1878a8ba4164497f9e07385733391e2b/grpcio-1.71.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e6beeea5566092c5e3c4896c6d1d307fb46b1d4bdf3e70c8340b190a69198594", size = 6312051 },
+    { url = "https://files.pythonhosted.org/packages/49/9d/e12ddc726dc8bd1aa6cba67c85ce42a12ba5b9dd75d5042214a59ccf28ce/grpcio-1.71.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5170929109450a2c031cfe87d6716f2fae39695ad5335d9106ae88cc32dc84c", size = 5910666 },
+    { url = "https://files.pythonhosted.org/packages/d9/e9/38713d6d67aedef738b815763c25f092e0454dc58e77b1d2a51c9d5b3325/grpcio-1.71.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:5b08d03ace7aca7b2fadd4baf291139b4a5f058805a8327bfe9aece7253b6d67", size = 6012019 },
+    { url = "https://files.pythonhosted.org/packages/80/da/4813cd7adbae6467724fa46c952d7aeac5e82e550b1c62ed2aeb78d444ae/grpcio-1.71.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:f903017db76bf9cc2b2d8bdd37bf04b505bbccad6be8a81e1542206875d0e9db", size = 6637043 },
+    { url = "https://files.pythonhosted.org/packages/52/ca/c0d767082e39dccb7985c73ab4cf1d23ce8613387149e9978c70c3bf3b07/grpcio-1.71.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:469f42a0b410883185eab4689060a20488a1a0a00f8bbb3cbc1061197b4c5a79", size = 6186143 },
+    { url = "https://files.pythonhosted.org/packages/00/61/7b2c8ec13303f8fe36832c13d91ad4d4ba57204b1c723ada709c346b2271/grpcio-1.71.0-cp312-cp312-win32.whl", hash = "sha256:ad9f30838550695b5eb302add33f21f7301b882937460dd24f24b3cc5a95067a", size = 3604083 },
+    { url = "https://files.pythonhosted.org/packages/fd/7c/1e429c5fb26122055d10ff9a1d754790fb067d83c633ff69eddcf8e3614b/grpcio-1.71.0-cp312-cp312-win_amd64.whl", hash = "sha256:652350609332de6dac4ece254e5d7e1ff834e203d6afb769601f286886f6f3a8", size = 4272191 },
+    { url = "https://files.pythonhosted.org/packages/04/dd/b00cbb45400d06b26126dcfdbdb34bb6c4f28c3ebbd7aea8228679103ef6/grpcio-1.71.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:cebc1b34ba40a312ab480ccdb396ff3c529377a2fce72c45a741f7215bfe8379", size = 5184138 },
+    { url = "https://files.pythonhosted.org/packages/ed/0a/4651215983d590ef53aac40ba0e29dda941a02b097892c44fa3357e706e5/grpcio-1.71.0-cp313-cp313-macosx_10_14_universal2.whl", hash = "sha256:85da336e3649a3d2171e82f696b5cad2c6231fdd5bad52616476235681bee5b3", size = 11310747 },
+    { url = "https://files.pythonhosted.org/packages/57/a3/149615b247f321e13f60aa512d3509d4215173bdb982c9098d78484de216/grpcio-1.71.0-cp313-cp313-manylinux_2_17_aarch64.whl", hash = "sha256:f9a412f55bb6e8f3bb000e020dbc1e709627dcb3a56f6431fa7076b4c1aab0db", size = 5653991 },
+    { url = "https://files.pythonhosted.org/packages/ca/56/29432a3e8d951b5e4e520a40cd93bebaa824a14033ea8e65b0ece1da6167/grpcio-1.71.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:47be9584729534660416f6d2a3108aaeac1122f6b5bdbf9fd823e11fe6fbaa29", size = 6312781 },
+    { url = "https://files.pythonhosted.org/packages/a3/f8/286e81a62964ceb6ac10b10925261d4871a762d2a763fbf354115f9afc98/grpcio-1.71.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c9c80ac6091c916db81131d50926a93ab162a7e97e4428ffc186b6e80d6dda4", size = 5910479 },
+    { url = "https://files.pythonhosted.org/packages/35/67/d1febb49ec0f599b9e6d4d0d44c2d4afdbed9c3e80deb7587ec788fcf252/grpcio-1.71.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:789d5e2a3a15419374b7b45cd680b1e83bbc1e52b9086e49308e2c0b5bbae6e3", size = 6013262 },
+    { url = "https://files.pythonhosted.org/packages/a1/04/f9ceda11755f0104a075ad7163fc0d96e2e3a9fe25ef38adfc74c5790daf/grpcio-1.71.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:1be857615e26a86d7363e8a163fade914595c81fec962b3d514a4b1e8760467b", size = 6643356 },
+    { url = "https://files.pythonhosted.org/packages/fb/ce/236dbc3dc77cf9a9242adcf1f62538734ad64727fabf39e1346ad4bd5c75/grpcio-1.71.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a76d39b5fafd79ed604c4be0a869ec3581a172a707e2a8d7a4858cb05a5a7637", size = 6186564 },
+    { url = "https://files.pythonhosted.org/packages/10/fd/b3348fce9dd4280e221f513dd54024e765b21c348bc475516672da4218e9/grpcio-1.71.0-cp313-cp313-win32.whl", hash = "sha256:74258dce215cb1995083daa17b379a1a5a87d275387b7ffe137f1d5131e2cfbb", size = 3601890 },
+    { url = "https://files.pythonhosted.org/packages/be/f8/db5d5f3fc7e296166286c2a397836b8b042f7ad1e11028d82b061701f0f7/grpcio-1.71.0-cp313-cp313-win_amd64.whl", hash = "sha256:22c3bc8d488c039a199f7a003a38cb7635db6656fa96437a8accde8322ce2366", size = 4273308 },
 ]
 
 [[package]]
@@ -279,6 +337,47 @@ wheels = [
 ]
 
 [[package]]
+name = "msgpack"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/d0/7555686ae7ff5731205df1012ede15dd9d927f6227ea151e901c7406af4f/msgpack-1.1.0.tar.gz", hash = "sha256:dd432ccc2c72b914e4cb77afce64aab761c1137cc698be3984eee260bcb2896e", size = 167260 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/5e/a4c7154ba65d93be91f2f1e55f90e76c5f91ccadc7efc4341e6f04c8647f/msgpack-1.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3d364a55082fb2a7416f6c63ae383fbd903adb5a6cf78c5b96cc6316dc1cedc7", size = 150803 },
+    { url = "https://files.pythonhosted.org/packages/60/c2/687684164698f1d51c41778c838d854965dd284a4b9d3a44beba9265c931/msgpack-1.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:79ec007767b9b56860e0372085f8504db5d06bd6a327a335449508bbee9648fa", size = 84343 },
+    { url = "https://files.pythonhosted.org/packages/42/ae/d3adea9bb4a1342763556078b5765e666f8fdf242e00f3f6657380920972/msgpack-1.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6ad622bf7756d5a497d5b6836e7fc3752e2dd6f4c648e24b1803f6048596f701", size = 81408 },
+    { url = "https://files.pythonhosted.org/packages/dc/17/6313325a6ff40ce9c3207293aee3ba50104aed6c2c1559d20d09e5c1ff54/msgpack-1.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e59bca908d9ca0de3dc8684f21ebf9a690fe47b6be93236eb40b99af28b6ea6", size = 396096 },
+    { url = "https://files.pythonhosted.org/packages/a8/a1/ad7b84b91ab5a324e707f4c9761633e357820b011a01e34ce658c1dda7cc/msgpack-1.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e1da8f11a3dd397f0a32c76165cf0c4eb95b31013a94f6ecc0b280c05c91b59", size = 403671 },
+    { url = "https://files.pythonhosted.org/packages/bb/0b/fd5b7c0b308bbf1831df0ca04ec76fe2f5bf6319833646b0a4bd5e9dc76d/msgpack-1.1.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:452aff037287acb1d70a804ffd022b21fa2bb7c46bee884dbc864cc9024128a0", size = 387414 },
+    { url = "https://files.pythonhosted.org/packages/f0/03/ff8233b7c6e9929a1f5da3c7860eccd847e2523ca2de0d8ef4878d354cfa/msgpack-1.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8da4bf6d54ceed70e8861f833f83ce0814a2b72102e890cbdfe4b34764cdd66e", size = 383759 },
+    { url = "https://files.pythonhosted.org/packages/1f/1b/eb82e1fed5a16dddd9bc75f0854b6e2fe86c0259c4353666d7fab37d39f4/msgpack-1.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:41c991beebf175faf352fb940bf2af9ad1fb77fd25f38d9142053914947cdbf6", size = 394405 },
+    { url = "https://files.pythonhosted.org/packages/90/2e/962c6004e373d54ecf33d695fb1402f99b51832631e37c49273cc564ffc5/msgpack-1.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a52a1f3a5af7ba1c9ace055b659189f6c669cf3657095b50f9602af3a3ba0fe5", size = 396041 },
+    { url = "https://files.pythonhosted.org/packages/f8/20/6e03342f629474414860c48aeffcc2f7f50ddaf351d95f20c3f1c67399a8/msgpack-1.1.0-cp311-cp311-win32.whl", hash = "sha256:58638690ebd0a06427c5fe1a227bb6b8b9fdc2bd07701bec13c2335c82131a88", size = 68538 },
+    { url = "https://files.pythonhosted.org/packages/aa/c4/5a582fc9a87991a3e6f6800e9bb2f3c82972912235eb9539954f3e9997c7/msgpack-1.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:fd2906780f25c8ed5d7b323379f6138524ba793428db5d0e9d226d3fa6aa1788", size = 74871 },
+    { url = "https://files.pythonhosted.org/packages/e1/d6/716b7ca1dbde63290d2973d22bbef1b5032ca634c3ff4384a958ec3f093a/msgpack-1.1.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:d46cf9e3705ea9485687aa4001a76e44748b609d260af21c4ceea7f2212a501d", size = 152421 },
+    { url = "https://files.pythonhosted.org/packages/70/da/5312b067f6773429cec2f8f08b021c06af416bba340c912c2ec778539ed6/msgpack-1.1.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5dbad74103df937e1325cc4bfeaf57713be0b4f15e1c2da43ccdd836393e2ea2", size = 85277 },
+    { url = "https://files.pythonhosted.org/packages/28/51/da7f3ae4462e8bb98af0d5bdf2707f1b8c65a0d4f496e46b6afb06cbc286/msgpack-1.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:58dfc47f8b102da61e8949708b3eafc3504509a5728f8b4ddef84bd9e16ad420", size = 82222 },
+    { url = "https://files.pythonhosted.org/packages/33/af/dc95c4b2a49cff17ce47611ca9ba218198806cad7796c0b01d1e332c86bb/msgpack-1.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4676e5be1b472909b2ee6356ff425ebedf5142427842aa06b4dfd5117d1ca8a2", size = 392971 },
+    { url = "https://files.pythonhosted.org/packages/f1/54/65af8de681fa8255402c80eda2a501ba467921d5a7a028c9c22a2c2eedb5/msgpack-1.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17fb65dd0bec285907f68b15734a993ad3fc94332b5bb21b0435846228de1f39", size = 401403 },
+    { url = "https://files.pythonhosted.org/packages/97/8c/e333690777bd33919ab7024269dc3c41c76ef5137b211d776fbb404bfead/msgpack-1.1.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a51abd48c6d8ac89e0cfd4fe177c61481aca2d5e7ba42044fd218cfd8ea9899f", size = 385356 },
+    { url = "https://files.pythonhosted.org/packages/57/52/406795ba478dc1c890559dd4e89280fa86506608a28ccf3a72fbf45df9f5/msgpack-1.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2137773500afa5494a61b1208619e3871f75f27b03bcfca7b3a7023284140247", size = 383028 },
+    { url = "https://files.pythonhosted.org/packages/e7/69/053b6549bf90a3acadcd8232eae03e2fefc87f066a5b9fbb37e2e608859f/msgpack-1.1.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:398b713459fea610861c8a7b62a6fec1882759f308ae0795b5413ff6a160cf3c", size = 391100 },
+    { url = "https://files.pythonhosted.org/packages/23/f0/d4101d4da054f04274995ddc4086c2715d9b93111eb9ed49686c0f7ccc8a/msgpack-1.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:06f5fd2f6bb2a7914922d935d3b8bb4a7fff3a9a91cfce6d06c13bc42bec975b", size = 394254 },
+    { url = "https://files.pythonhosted.org/packages/1c/12/cf07458f35d0d775ff3a2dc5559fa2e1fcd06c46f1ef510e594ebefdca01/msgpack-1.1.0-cp312-cp312-win32.whl", hash = "sha256:ad33e8400e4ec17ba782f7b9cf868977d867ed784a1f5f2ab46e7ba53b6e1e1b", size = 69085 },
+    { url = "https://files.pythonhosted.org/packages/73/80/2708a4641f7d553a63bc934a3eb7214806b5b39d200133ca7f7afb0a53e8/msgpack-1.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:115a7af8ee9e8cddc10f87636767857e7e3717b7a2e97379dc2054712693e90f", size = 75347 },
+    { url = "https://files.pythonhosted.org/packages/c8/b0/380f5f639543a4ac413e969109978feb1f3c66e931068f91ab6ab0f8be00/msgpack-1.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:071603e2f0771c45ad9bc65719291c568d4edf120b44eb36324dcb02a13bfddf", size = 151142 },
+    { url = "https://files.pythonhosted.org/packages/c8/ee/be57e9702400a6cb2606883d55b05784fada898dfc7fd12608ab1fdb054e/msgpack-1.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0f92a83b84e7c0749e3f12821949d79485971f087604178026085f60ce109330", size = 84523 },
+    { url = "https://files.pythonhosted.org/packages/7e/3a/2919f63acca3c119565449681ad08a2f84b2171ddfcff1dba6959db2cceb/msgpack-1.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4a1964df7b81285d00a84da4e70cb1383f2e665e0f1f2a7027e683956d04b734", size = 81556 },
+    { url = "https://files.pythonhosted.org/packages/7c/43/a11113d9e5c1498c145a8925768ea2d5fce7cbab15c99cda655aa09947ed/msgpack-1.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:59caf6a4ed0d164055ccff8fe31eddc0ebc07cf7326a2aaa0dbf7a4001cd823e", size = 392105 },
+    { url = "https://files.pythonhosted.org/packages/2d/7b/2c1d74ca6c94f70a1add74a8393a0138172207dc5de6fc6269483519d048/msgpack-1.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0907e1a7119b337971a689153665764adc34e89175f9a34793307d9def08e6ca", size = 399979 },
+    { url = "https://files.pythonhosted.org/packages/82/8c/cf64ae518c7b8efc763ca1f1348a96f0e37150061e777a8ea5430b413a74/msgpack-1.1.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:65553c9b6da8166e819a6aa90ad15288599b340f91d18f60b2061f402b9a4915", size = 383816 },
+    { url = "https://files.pythonhosted.org/packages/69/86/a847ef7a0f5ef3fa94ae20f52a4cacf596a4e4a010197fbcc27744eb9a83/msgpack-1.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7a946a8992941fea80ed4beae6bff74ffd7ee129a90b4dd5cf9c476a30e9708d", size = 380973 },
+    { url = "https://files.pythonhosted.org/packages/aa/90/c74cf6e1126faa93185d3b830ee97246ecc4fe12cf9d2d31318ee4246994/msgpack-1.1.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4b51405e36e075193bc051315dbf29168d6141ae2500ba8cd80a522964e31434", size = 387435 },
+    { url = "https://files.pythonhosted.org/packages/7a/40/631c238f1f338eb09f4acb0f34ab5862c4e9d7eda11c1b685471a4c5ea37/msgpack-1.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b4c01941fd2ff87c2a934ee6055bda4ed353a7846b8d4f341c428109e9fcde8c", size = 399082 },
+    { url = "https://files.pythonhosted.org/packages/e9/1b/fa8a952be252a1555ed39f97c06778e3aeb9123aa4cccc0fd2acd0b4e315/msgpack-1.1.0-cp313-cp313-win32.whl", hash = "sha256:7c9a35ce2c2573bada929e0b7b3576de647b0defbd25f5139dcdaba0ae35a4cc", size = 69037 },
+    { url = "https://files.pythonhosted.org/packages/b6/bc/8bd826dd03e022153bfa1766dcdec4976d6c818865ed54223d71f07862b3/msgpack-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:bce7d9e614a04d0883af0b3d4d501171fbfca038f12c77fa838d9f198147a23f", size = 75140 },
+]
+
+[[package]]
 name = "mypy"
 version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -371,6 +470,20 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "5.29.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/7d/b9dca7365f0e2c4fa7c193ff795427cfa6290147e5185ab11ece280a18e7/protobuf-5.29.4.tar.gz", hash = "sha256:4f1dfcd7997b31ef8f53ec82781ff434a28bf71d9102ddde14d076adcfc78c99", size = 424902 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/b2/043a1a1a20edd134563699b0e91862726a0dc9146c090743b6c44d798e75/protobuf-5.29.4-cp310-abi3-win32.whl", hash = "sha256:13eb236f8eb9ec34e63fc8b1d6efd2777d062fa6aaa68268fb67cf77f6839ad7", size = 422709 },
+    { url = "https://files.pythonhosted.org/packages/79/fc/2474b59570daa818de6124c0a15741ee3e5d6302e9d6ce0bdfd12e98119f/protobuf-5.29.4-cp310-abi3-win_amd64.whl", hash = "sha256:bcefcdf3976233f8a502d265eb65ea740c989bacc6c30a58290ed0e519eb4b8d", size = 434506 },
+    { url = "https://files.pythonhosted.org/packages/46/de/7c126bbb06aa0f8a7b38aaf8bd746c514d70e6a2a3f6dd460b3b7aad7aae/protobuf-5.29.4-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:307ecba1d852ec237e9ba668e087326a67564ef83e45a0189a772ede9e854dd0", size = 417826 },
+    { url = "https://files.pythonhosted.org/packages/a2/b5/bade14ae31ba871a139aa45e7a8183d869efe87c34a4850c87b936963261/protobuf-5.29.4-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:aec4962f9ea93c431d5714ed1be1c93f13e1a8618e70035ba2b0564d9e633f2e", size = 319574 },
+    { url = "https://files.pythonhosted.org/packages/46/88/b01ed2291aae68b708f7d334288ad5fb3e7aa769a9c309c91a0d55cb91b0/protobuf-5.29.4-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:d7d3f7d1d5a66ed4942d4fefb12ac4b14a29028b209d4bfb25c68ae172059922", size = 319672 },
+    { url = "https://files.pythonhosted.org/packages/12/fb/a586e0c973c95502e054ac5f81f88394f24ccc7982dac19c515acd9e2c93/protobuf-5.29.4-py3-none-any.whl", hash = "sha256:3fde11b505e1597f71b875ef2fc52062b6a9740e5f7c8997ce878b6009145862", size = 172551 },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -393,6 +506,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
 ]
+
+[[package]]
+name = "python-rapidjson"
+version = "1.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/85/393d6bd7965402e92a77f1040935c5fc6403a0c7fa7018b03c6f4ba488c7/python-rapidjson-1.8.tar.gz", hash = "sha256:170c2ff97d01735f67afd0e1cb0aaa690cb69ae6016e020c6afd5e0ab9b39899", size = 222766 }
 
 [[package]]
 name = "pyyaml"
@@ -565,6 +684,37 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-kafka-schemas"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastjsonschema" },
+    { name = "msgpack" },
+    { name = "python-rapidjson" },
+    { name = "pyyaml" },
+    { name = "sentry-protos" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/b7/f2306a77ae1a1b27559dfa7d821aaf1d56f0caa272d187780999bee54ac4/sentry-kafka-schemas-1.2.0.tar.gz", hash = "sha256:06b9b686616f82e88625ca1ce8bcc0b8d40b3182942ac74d4f5ef135c3552fae", size = 142180 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ea/0779ff5e4c43876d172e0ef36c3fa9ee18f8615e757a5d9a8c8809ab6f5a/sentry_kafka_schemas-1.2.0-py2.py3-none-any.whl", hash = "sha256:30a3798bdfb77d1c59c44bc72eca055a333faa31b98b2c6e04bcb8798eba16cb", size = 259391 },
+]
+
+[[package]]
+name = "sentry-protos"
+version = "0.1.70"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpc-stubs" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/4b/7ff02993ab817a9fb31185fd268d1378395a742b54ea225b6fbefb17065f/sentry_protos-0.1.70.tar.gz", hash = "sha256:87623fb9cc2c3950aace05abb5f652cb01375279c92a76a9fc7c10f834b5a37e", size = 122121 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/fb/f7886bebe25a72ee8801e74a1e29970a01e6cad701f5f62eef9505ea3b9f/sentry_protos-0.1.70-py3-none-any.whl", hash = "sha256:11b8a7f5252f2524296b722ec421290dfc2894bd26f19cc6ee55a1cbdd0c18b6", size = 195486 },
+]
+
+[[package]]
 name = "sentry-streams"
 version = "0.0.16"
 source = { editable = "." }
@@ -573,6 +723,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "sentry-arroyo" },
+    { name = "sentry-kafka-schemas" },
 ]
 
 [package.dev-dependencies]
@@ -597,6 +748,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "sentry-arroyo", specifier = ">=2.18.2" },
+    { name = "sentry-kafka-schemas", specifier = ">=1.2.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Does the following:

- Links types of different steps of an ExtensibleChain
- Provides a simple Message class to carry message metadata through the pipeline. This allows for decoupling certain steps, like parsing/deserialization from the stream source step. 
- Basic message decoders/encoders provided out of the box in the API (JSON, protobuf)
- Basic header filtering in the source
- Schema validation and transforming raw bytes into a schema-enforced message type
- General type checks
- Unit tests cleanup


Still to do:

- Improve a bunch of naming (of interfaces, of files, etc.)
- Provide full support for Protobuf