### PR TITLE
Add some content to the readme

### DIFF
--- a/sentry_streams/README.md
+++ b/sentry_streams/README.md
@@ -1,0 +1,8 @@
+# The Sentry Streaming Platform
+
+Sentry Streams is a distributed platform that, like most streaming platforms,
+is designed to handle real-time unbounded data streams.
+
+This is built primarily to allow the creation of Sentry ingestion pipelines
+though the api provided is fully independent from the Sentry product and can
+be used to build any streaming application.


### PR DESCRIPTION
When I tried to publish this package built by maturin I get this error from 
pypi:

```
wine: 25hWARNING  Error during upload. Retry with the --verbose option for more details. 
twine: ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
twine:          The description failed to render for 'text/markdown; charset=UTF-8;    
twine:          variant=GFM'. See https://pypi.org/help/#description-content-type for  
twine:          more information.                                                      
twine: 
```

It seems the difference between maturin and setuptools is the readme content encoding.
setuptools:
`Description-Content-Type: text/markdown` 

maturin
`text/markdown; charset=UTF-8; variant=GFM`

which apaprently makes pypi unhappy if the readme is empty.
Trying to add some content.
