### PR TITLE
ref(ci): Disable extension-module by default

### DIFF
--- a/.github/workflows/build-streams.yaml
+++ b/.github/workflows/build-streams.yaml
@@ -1,6 +1,7 @@
 name: build sentry_streams
 
 on:
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/build-streams.yaml
+++ b/.github/workflows/build-streams.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: PyO3/maturin-action@aef21716ff3dcae8a1c301d23ec3e4446972a6e3
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist --find-interpreter --features=extension-module
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: "2014"
           working-directory: ./sentry_streams

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Checkout code
-      - run: cargo check
+      - run: cargo check --all-features
         working-directory: ./sentry_streams
       - run: cargo fmt --check
         working-directory: ./sentry_streams
@@ -30,4 +30,4 @@ jobs:
         name: Checkout code
       - name: Run tests
         working-directory: ./sentry_streams
-        run: cargo test --no-default-features
+        run: cargo test

--- a/sentry_streams/Cargo.toml
+++ b/sentry_streams/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 
 [features]
 extension-module = ["pyo3/extension-module"]
-default = ["extension-module"]
+default = []
 
 [dev-dependencies]
 parking_lot = "0.12.1"

--- a/sentry_streams/Cargo.toml
+++ b/sentry_streams/Cargo.toml
@@ -19,7 +19,6 @@ crate-type = ["cdylib"]
 
 [features]
 extension-module = ["pyo3/extension-module"]
-default = []
 
 [dev-dependencies]
 parking_lot = "0.12.1"


### PR DESCRIPTION
Since people interact with cargo directly in local development, i'd argue for the sake of ergonomics that the features should default to what is needed in local development. For the release job we can have a longer list of arguments. Going to run the build-streams job as well in CI, because it'd suck if any breakage is only revealed during release.