### PR TITLE
Move the Message data structure to Rust

### DIFF
--- a/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/adapter.py
@@ -16,8 +16,6 @@ from arroyo.backends.kafka.configuration import (
 from arroyo.backends.kafka.consumer import KafkaConsumer, KafkaPayload, KafkaProducer
 from arroyo.processing.processor import StreamProcessor
 from arroyo.types import Topic
-from sentry_kafka_schemas import get_codec
-from sentry_kafka_schemas.codecs import Codec
 
 from sentry_streams.adapters.arroyo.consumer import (
     ArroyoConsumer,
@@ -153,13 +151,9 @@ class ArroyoAdapter(StreamAdapter[Route, Route]):
 
         # This is the Arroyo adapter, and it only supports consuming from StreamSource anyways
         assert isinstance(step, StreamSource)
-        try:
-            schema: Codec[Any] = get_codec(step.stream_name)
-        except Exception:
-            raise ValueError(f"Kafka topic {step.stream_name} has no associated schema")
 
         self.__consumers[source_name] = ArroyoConsumer(
-            source_name, step.stream_name, schema, step.header_filter
+            source_name, step.stream_name, step.stream_name, step.header_filter
         )
 
         return Route(source_name, [])

--- a/sentry_streams/sentry_streams/adapters/arroyo/consumer.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/consumer.py
@@ -11,7 +11,6 @@ from arroyo.processing.strategies.abstract import (
 )
 from arroyo.processing.strategies.run_task import RunTask
 from arroyo.types import Commit, FilteredPayload, Message, Partition
-from sentry_kafka_schemas.codecs import Codec
 
 from sentry_streams.adapters.arroyo.routes import Route, RoutedValue
 from sentry_streams.adapters.arroyo.steps import ArroyoStep
@@ -41,7 +40,7 @@ class ArroyoConsumer:
 
     source: str
     stream_name: str
-    schema: Codec[Any]
+    schema: str
     header_filter: Optional[Tuple[str, bytes]] = None
     steps: MutableSequence[ArroyoStep] = field(default_factory=list)
 

--- a/sentry_streams/sentry_streams/adapters/arroyo/consumer.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/consumer.py
@@ -14,7 +14,7 @@ from arroyo.types import Commit, FilteredPayload, Message, Partition
 
 from sentry_streams.adapters.arroyo.routes import Route, RoutedValue
 from sentry_streams.adapters.arroyo.steps import ArroyoStep
-from sentry_streams.pipeline.message import Message as StreamsMessage
+from sentry_streams.pipeline.message import PyMessage as StreamsMessage
 
 logger = logging.getLogger(__name__)
 

--- a/sentry_streams/sentry_streams/adapters/arroyo/msg_wrapper.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/msg_wrapper.py
@@ -5,7 +5,7 @@ from arroyo.processing.strategies.abstract import ProcessingStrategy
 from arroyo.types import FilteredPayload, Message, Value
 
 from sentry_streams.adapters.arroyo.routes import Route, RoutedValue
-from sentry_streams.pipeline.message import Message as StreamsMessage
+from sentry_streams.pipeline.message import PyMessage as StreamsMessage
 
 TPayload = TypeVar("TPayload")
 

--- a/sentry_streams/sentry_streams/adapters/arroyo/rust_arroyo.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/rust_arroyo.py
@@ -9,9 +9,6 @@ from typing import (
     cast,
 )
 
-from sentry_kafka_schemas import get_codec
-from sentry_kafka_schemas.codecs import Codec
-
 from sentry_streams.adapters.arroyo.routers import build_branches
 from sentry_streams.adapters.arroyo.routes import Route
 from sentry_streams.adapters.stream_adapter import PipelineConfig, StreamAdapter
@@ -141,11 +138,7 @@ class RustArroyoAdapter(StreamAdapter[Route, Route]):
         )
 
         def make_msg(payload: Any) -> Message[Any]:
-            try:
-                schema: Codec[Any] = get_codec(step.stream_name)
-            except Exception:
-                raise ValueError(f"Kafka topic {step.stream_name} has no associated schema")
-            return Message(payload=payload, headers=[], timestamp=0, schema=schema)
+            return Message(payload=payload, headers=[], timestamp=0, schema=step.stream_name)
 
         route = RustRoute(source_name, [])
         self.__consumers[source_name].add_step(RuntimeOperator.Map(route, make_msg))

--- a/sentry_streams/sentry_streams/adapters/arroyo/rust_arroyo.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/rust_arroyo.py
@@ -21,7 +21,7 @@ from sentry_streams.pipeline.function_template import (
     InputType,
     OutputType,
 )
-from sentry_streams.pipeline.message import Message
+from sentry_streams.pipeline.message import Message, PyMessage
 from sentry_streams.pipeline.pipeline import (
     Broadcast,
     Filter,
@@ -138,7 +138,7 @@ class RustArroyoAdapter(StreamAdapter[Route, Route]):
         )
 
         def make_msg(payload: Any) -> Message[Any]:
-            return Message(payload=payload, headers=[], timestamp=0, schema=step.stream_name)
+            return PyMessage(payload=payload, headers=[], timestamp=0, schema=step.stream_name)
 
         route = RustRoute(source_name, [])
         self.__consumers[source_name].add_step(RuntimeOperator.Map(route, make_msg))
@@ -176,7 +176,7 @@ class RustArroyoAdapter(StreamAdapter[Route, Route]):
         ), f"Stream starting at source {stream.source} not found when adding a map"
 
         def transform_msg(msg: Message[Any]) -> Message[Any]:
-            return Message(
+            return PyMessage(
                 payload=step.resolved_function(msg),
                 headers=msg.headers,
                 timestamp=msg.timestamp,

--- a/sentry_streams/sentry_streams/adapters/arroyo/steps.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/steps.py
@@ -14,7 +14,7 @@ from sentry_streams.adapters.arroyo.forwarder import Forwarder
 from sentry_streams.adapters.arroyo.msg_wrapper import MessageWrapper
 from sentry_streams.adapters.arroyo.reduce import build_arroyo_windowed_reduce
 from sentry_streams.adapters.arroyo.routes import Route, RoutedValue
-from sentry_streams.pipeline.message import Message as StreamsMessage
+from sentry_streams.pipeline.message import PyMessage as StreamsMessage
 from sentry_streams.pipeline.pipeline import (
     Broadcast,
     Filter,

--- a/sentry_streams/sentry_streams/examples/simple_map_filter.py
+++ b/sentry_streams/sentry_streams/examples/simple_map_filter.py
@@ -1,42 +1,33 @@
-from json import JSONDecodeError, dumps, loads
-from typing import Any, Mapping, cast
+from typing import Any, Mapping
 
-from sentry_streams.pipeline import Filter, Map, streaming_source
+from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
+
+from sentry_streams.pipeline import Filter, Map, Parser, Serializer, streaming_source
 from sentry_streams.pipeline.message import Message
 
 
-def parse(msg: Message[bytes]) -> Mapping[str, Any]:
-    try:
-        parsed = loads(msg.payload)
-    except JSONDecodeError:
-        return {"type": "invalid"}
-
-    return cast(Mapping[str, Any], parsed)
+def filter_events(msg: Message[IngestMetric]) -> bool:
+    return bool(msg.payload["type"] == "c")
 
 
-def transform_msg(msg: Message[Mapping[str, Any]]) -> Mapping[str, Any]:
+def transform_msg(msg: Message[IngestMetric]) -> Mapping[str, Any]:
     return {**msg.payload, "transformed": True}
-
-
-def filter_events(msg: Message[Mapping[str, Any]]) -> bool:
-    return "event" in msg.payload
-
-
-def serialize_msg(msg: Message[Mapping[str, Any]]) -> bytes:
-    ret = dumps(msg.payload).encode()
-    print(f"PROCESSING {msg}")
-    return ret
 
 
 # A pipline with a few transformations
 pipeline = (
     streaming_source(
         name="myinput",
-        stream_name="events",
+        stream_name="ingest-metrics",
     )
-    .apply("mymap", Map(function=parse))
+    .apply(
+        "parser",
+        Parser(
+            msg_type=IngestMetric,
+        ),
+    )
     .apply("filter", Filter(function=filter_events))
     .apply("transform", Map(function=transform_msg))
-    .apply("serializer", Map(function=serialize_msg))
+    .apply("serializer", Serializer())
     .sink("mysink", "transformed-events")
 )

--- a/sentry_streams/sentry_streams/pipeline/__init__.py
+++ b/sentry_streams/sentry_streams/pipeline/__init__.py
@@ -3,7 +3,9 @@ from sentry_streams.pipeline.chain import (
     Filter,
     FlatMap,
     Map,
+    Parser,
     Reducer,
+    Serializer,
     multi_chain,
     segment,
     streaming_source,
@@ -18,4 +20,6 @@ __all__ = [
     "FlatMap",
     "Reducer",
     "Batch",
+    "Parser",
+    "Serializer",
 ]

--- a/sentry_streams/sentry_streams/pipeline/message.py
+++ b/sentry_streams/sentry_streams/pipeline/message.py
@@ -44,15 +44,6 @@ class Message(ABC, Generic[TPayload]):
             and self.schema == other.schema
         )
 
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}("
-            f"payload={self.payload!r}, "
-            f"headers={self.headers!r}, "
-            f"timestamp={self.timestamp!r}, "
-            f"schema={self.schema!r})"
-        )
-
 
 class PyMessage(Generic[TPayload], Message[TPayload]):
     """

--- a/sentry_streams/sentry_streams/pipeline/message.py
+++ b/sentry_streams/sentry_streams/pipeline/message.py
@@ -1,21 +1,60 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import (
-    Generic,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    cast,
-)
+from typing import Generic, Optional, Sequence, Tuple, TypeVar, cast
 
-from sentry_streams.rust_streams import PyAnyMessage
+from sentry_streams.rust_streams import PyAnyMessage, RawMessage
 
 TPayload = TypeVar("TPayload")
 
 
-class Message(Generic[TPayload]):
+class Message(ABC, Generic[TPayload]):
+    @property
+    @abstractmethod
+    def payload(self) -> TPayload:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def headers(self) -> Sequence[Tuple[str, bytes]]:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def timestamp(self) -> float:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def schema(self) -> str | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def deepcopy(self) -> Message[TPayload]:
+        raise NotImplementedError
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Message):
+            return False
+        return (
+            self.payload == other.payload
+            and self.headers == other.headers
+            and self.timestamp == other.timestamp
+            and self.schema == other.schema
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"payload={self.payload!r}, "
+            f"headers={self.headers!r}, "
+            f"timestamp={self.timestamp!r}, "
+            f"schema={self.schema!r})"
+        )
+
+
+class PyMessage(Generic[TPayload], Message[TPayload]):
     """
     A wrapper for the Rust PyAnyMessage to make the payload generic.
     We cannot export classes via PyO3 that are generic in Python.
@@ -47,29 +86,45 @@ class Message(Generic[TPayload]):
     def schema(self) -> str | None:
         return self.inner.schema
 
-    def deepcopy(self) -> Message[TPayload]:
-        return Message(
+    def deepcopy(self) -> PyMessage[TPayload]:
+        return PyMessage(
             deepcopy(self.inner.payload),
             deepcopy(self.inner.headers),
             self.inner.timestamp,
             self.inner.schema,
         )
 
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, Message):
-            return False
-        return (
-            self.payload == other.payload
-            and self.headers == other.headers
-            and self.timestamp == other.timestamp
-            and self.schema == other.schema
-        )
 
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}("
-            f"payload={self.payload!r}, "
-            f"headers={self.headers!r}, "
-            f"timestamp={self.timestamp!r}, "
-            f"schema={self.schema!r})"
+class PyRawMessage(Message[bytes]):
+    def __init__(
+        self,
+        payload: bytes,
+        headers: Sequence[Tuple[str, bytes]],
+        timestamp: float,
+        schema: Optional[str] = None,
+    ) -> None:
+        self.inner = RawMessage(payload, headers, timestamp, schema)
+
+    @property
+    def payload(self) -> bytes:
+        return self.inner.payload
+
+    @property
+    def headers(self) -> Sequence[Tuple[str, bytes]]:
+        return self.inner.headers
+
+    @property
+    def timestamp(self) -> float:
+        return self.inner.timestamp
+
+    @property
+    def schema(self) -> str | None:
+        return self.inner.schema
+
+    def deepcopy(self) -> PyRawMessage:
+        return PyRawMessage(
+            deepcopy(self.inner.payload),
+            deepcopy(self.inner.headers),
+            self.inner.timestamp,
+            self.inner.schema,
         )

--- a/sentry_streams/sentry_streams/pipeline/message.py
+++ b/sentry_streams/sentry_streams/pipeline/message.py
@@ -16,8 +16,8 @@ class Message(ABC, Generic[TPayload]):
 
     The actual Message classes are defined in Rust and are exported to Python
     via pyo3. This class and its subclasses wrap the Rust classes so that we
-    can make the payload time Generic. It is not possible to create, via pyo3,
-    a class that is generic to Python nor using Rust generics.
+    can make the payload of the Rust classes generic. It is not possible to
+    create, via pyo3, a class that is generic to Python nor using Rust generics.
 
     The other reason this class exists is to have a superclass for all message
     types in Python. In rust we have a rich enum.
@@ -65,6 +65,14 @@ class Message(ABC, Generic[TPayload]):
 class PyMessage(Generic[TPayload], Message[TPayload]):
     """
     A wrapper for the Rust PyAnyMessage to make the payload generic.
+
+    The payload of the inner rust class is `Any` for Python,
+    but this class casts it to a Generic type.
+    This does not offer the same guarantee as if the code was all
+    in Python as the Rust code may not respect the type hint.
+    By making this type generic we can still get a lot of guarantees
+    by the type checker when wiring python primitives together as
+    it can ensure primitives are compatible with each other.
     """
 
     def __init__(

--- a/sentry_streams/sentry_streams/pipeline/msg_parser.py
+++ b/sentry_streams/sentry_streams/pipeline/msg_parser.py
@@ -1,5 +1,8 @@
 import json
-from typing import Any
+from typing import Any, MutableMapping
+
+from sentry_kafka_schemas import get_codec
+from sentry_kafka_schemas.codecs import Codec
 
 from sentry_streams.pipeline.message import Message
 
@@ -7,14 +10,21 @@ from sentry_streams.pipeline.message import Message
 # Standard message decoders and encoders live here
 # These are used in the defintions of Parser() and Serializer() steps, see chain/
 
+CODECS: MutableMapping[str, Codec[Any]] = {}
+
 
 def msg_parser(msg: Message[bytes]) -> Any:
-    codec = msg.schema
+    stream_schema = msg.schema
     payload = msg.payload
 
     assert (
-        codec is not None
+        stream_schema is not None
     )  # Message cannot be deserialized without a schema, it is automatically inferred from the stream source
+
+    try:
+        codec = CODECS.get(stream_schema, get_codec(stream_schema))
+    except Exception:
+        raise ValueError(f"Kafka topic {stream_schema} has no associated schema")
 
     decoded = codec.decode(payload, True)
 

--- a/sentry_streams/sentry_streams/pipeline/msg_parser.py
+++ b/sentry_streams/sentry_streams/pipeline/msg_parser.py
@@ -4,7 +4,7 @@ from typing import Any, MutableMapping
 from sentry_kafka_schemas import get_codec
 from sentry_kafka_schemas.codecs import Codec
 
-from sentry_streams.pipeline.message import Message
+from sentry_streams.pipeline.message import Message, PyRawMessage
 
 # TODO: Push the following to docs
 # Standard message decoders and encoders live here
@@ -13,7 +13,7 @@ from sentry_streams.pipeline.message import Message
 CODECS: MutableMapping[str, Codec[Any]] = {}
 
 
-def msg_parser(msg: Message[bytes]) -> Any:
+def msg_parser(msg: PyRawMessage) -> Any:
     stream_schema = msg.schema
     payload = msg.payload
 

--- a/sentry_streams/sentry_streams/rust_streams.pyi
+++ b/sentry_streams/sentry_streams/rust_streams.pyi
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Callable, Mapping, Self, Sequence, TypeVar
+from typing import Any, Callable, Generic, Mapping, Self, Sequence, Tuple, TypeVar
 
 from sentry_streams.adapters.arroyo.rust_step import RustOperatorDelegate
 from sentry_streams.pipeline.message import Message
@@ -63,3 +63,37 @@ class ArroyoConsumer:
     def add_step(self, step: RuntimeOperator) -> None: ...
     def run(self) -> None: ...
     def shutdown(self) -> None: ...
+
+class PyAnyMessage:
+    def __init__(
+        self,
+        payload: Any,
+        headers: Sequence[Tuple[str, bytes]],
+        timestamp: float,
+        schema: str | None,
+    ) -> None: ...
+    @property
+    def payload(self) -> Any: ...
+    @property
+    def headers(self) -> Sequence[Tuple[str, bytes]]: ...
+    @property
+    def timestamp(self) -> float: ...
+    @property
+    def schema(self) -> str | None: ...
+
+class RawMessage:
+    def __init__(
+        self,
+        payload: bytes,
+        headers: Sequence[Tuple[str, bytes]],
+        timestamp: float,
+        schema: str | None,
+    ) -> None: ...
+    @property
+    def payload(self) -> bytes: ...
+    @property
+    def headers(self) -> Sequence[Tuple[str, bytes]]: ...
+    @property
+    def timestamp(self) -> float: ...
+    @property
+    def schema(self) -> str | None: ...

--- a/sentry_streams/src/lib.rs
+++ b/sentry_streams/src/lib.rs
@@ -3,6 +3,7 @@ mod callers;
 mod consumer;
 mod filter_step;
 mod kafka_config;
+mod messages;
 mod operators;
 mod python_operator;
 mod routers;
@@ -23,5 +24,7 @@ fn rust_streams(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<kafka_config::PyKafkaProducerConfig>()?;
     m.add_class::<kafka_config::InitialOffset>()?;
     m.add_class::<consumer::ArroyoConsumer>()?;
+    m.add_class::<messages::PyAnyMessage>()?;
+    m.add_class::<messages::RawMessage>()?;
     Ok(())
 }

--- a/sentry_streams/src/messages.rs
+++ b/sentry_streams/src/messages.rs
@@ -1,0 +1,159 @@
+use pyo3::types::{PyBytes, PyList, PyTuple};
+use pyo3::Python;
+
+use pyo3::{prelude::*, types::PySequence, IntoPyObjectExt};
+
+#[pyclass]
+#[derive(Debug)]
+pub struct PyAnyMessage {
+    #[pyo3(get, set)]
+    payload: Py<PyAny>,
+
+    headers: Vec<(String, Vec<u8>)>,
+
+    #[pyo3(get, set)]
+    timestamp: f64,
+
+    #[pyo3(get, set)]
+    schema: Option<String>,
+}
+
+fn headers_to_vec(headers: Py<PySequence>) -> PyResult<Vec<(String, Vec<u8>)>> {
+    Python::with_gil(|py| {
+        Ok(headers
+            .bind(py)
+            .try_iter()
+            .unwrap()
+            .map(|item| {
+                let tuple_i = item.unwrap();
+                let tuple = tuple_i.downcast::<pyo3::types::PyTuple>().unwrap();
+                let key = tuple.get_item(0).unwrap().unbind().extract(py).unwrap();
+                let value: Vec<u8> = tuple.get_item(1).unwrap().unbind().extract(py).unwrap();
+                (key, value)
+            })
+            .collect())
+    })
+}
+
+fn headers_to_sequence(headers: &[(String, Vec<u8>)], py: Python<'_>) -> PyResult<Py<PySequence>> {
+    let py_tuples = headers
+        .iter()
+        .map(|(k, v)| {
+            let py_key = k.into_py_any(py).unwrap();
+            let py_value = v.into_py_any(py).unwrap();
+            PyTuple::new(py, &[py_key, py_value]).unwrap()
+        })
+        .collect::<Vec<_>>();
+    let list = PyList::new(py, py_tuples).unwrap();
+    let seq = list.into_sequence();
+    Ok(seq.unbind())
+}
+
+#[pymethods]
+impl PyAnyMessage {
+    #[new]
+    pub fn new(
+        payload: Py<PyAny>,
+        headers: Py<PySequence>,
+        timestamp: f64,
+        schema: Option<String>,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            payload,
+            headers: headers_to_vec(headers)?,
+            timestamp,
+            schema,
+        })
+    }
+
+    #[getter]
+    fn headers(&self, py: Python<'_>) -> PyResult<Py<PySequence>> {
+        headers_to_sequence(&self.headers, py)
+    }
+}
+
+#[pyclass]
+#[derive(Debug)]
+pub struct RawMessage {
+    payload: Vec<u8>,
+
+    headers: Vec<(String, Vec<u8>)>,
+
+    #[pyo3(get, set)]
+    timestamp: f64,
+
+    #[pyo3(get, set)]
+    schema: Option<String>,
+}
+
+#[pymethods]
+impl RawMessage {
+    #[new]
+    pub fn new(
+        payload: Py<PyBytes>,
+        headers: Py<PySequence>,
+        timestamp: f64,
+        schema: Option<String>,
+        py: Python,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            payload: payload.as_bytes(py).to_vec(),
+            headers: headers_to_vec(headers)?,
+            timestamp,
+            schema,
+        })
+    }
+
+    #[getter]
+    fn headers(&self, py: Python) -> PyResult<Py<PySequence>> {
+        headers_to_sequence(&self.headers, py)
+    }
+
+    #[getter]
+    fn payload(&self, py: Python) -> PyResult<Py<PyBytes>> {
+        Ok(PyBytes::new(py, &self.payload).unbind())
+    }
+}
+
+#[derive(Debug)]
+pub enum StreamingMessage {
+    PyAnyMessage(PyAnyMessage),
+    RawMessage(RawMessage),
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_headers_to_vec_and_sequence_roundtrip() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let headers = vec![
+                ("key1".to_string(), vec![1, 2, 3]),
+                ("key2".to_string(), vec![4, 5, 6]),
+            ];
+            let py_tuples: Vec<_> = headers
+                .iter()
+                .map(|(k, v)| {
+                    PyTuple::new(
+                        py,
+                        &[
+                            k.into_py_any(py).unwrap(),
+                            PyBytes::new(py, v).into_py_any(py).unwrap(),
+                        ],
+                    )
+                    .unwrap()
+                })
+                .collect();
+            let py_list = PyList::new(py, py_tuples);
+            let py_seq = py_list.unwrap().into_sequence();
+
+            let headers_vec = headers_to_vec(py_seq.unbind()).unwrap();
+            assert_eq!(headers_vec, headers);
+
+            let py_seq2 = headers_to_sequence(&headers_vec, py).unwrap();
+            let headers_vec2 = headers_to_vec(py_seq2.extract(py).unwrap()).unwrap();
+            assert_eq!(headers_vec2, headers);
+        });
+    }
+}

--- a/sentry_streams/tests/adapters/arroyo/test_broadcaster.py
+++ b/sentry_streams/tests/adapters/arroyo/test_broadcaster.py
@@ -9,7 +9,7 @@ from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 
 from sentry_streams.adapters.arroyo.broadcaster import Broadcaster
 from sentry_streams.adapters.arroyo.routes import Route
-from sentry_streams.pipeline.message import Message
+from sentry_streams.pipeline.message import PyMessage
 from tests.adapters.arroyo.message_helpers import make_value_msg
 
 
@@ -21,7 +21,7 @@ def test_submit_routedvalue(metric: IngestMetric) -> None:
         next_step=next_step,
     )
 
-    msg = Message(metric, [], time.time(), None)
+    msg = PyMessage(metric, [], time.time(), None)
     message = make_value_msg(payload=msg, route=Route(source="source", waypoints=[]), offset=0)
 
     expected_calls = [
@@ -88,7 +88,7 @@ def test_message_rejected(metric: IngestMetric) -> None:
         next_step=next_step,
     )
 
-    msg = Message(metric, [], time.time(), None)
+    msg = PyMessage(metric, [], time.time(), None)
     message = make_value_msg(payload=msg, route=Route(source="source", waypoints=[]), offset=0)
 
     message_rejected_expected_call = call(

--- a/sentry_streams/tests/adapters/arroyo/test_consumer.py
+++ b/sentry_streams/tests/adapters/arroyo/test_consumer.py
@@ -50,7 +50,9 @@ def test_single_route(
     """
     empty_route = Route(source="source1", waypoints=[])
 
-    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics", schema=SCHEMA)
+    consumer = ArroyoConsumer(
+        source="source1", stream_name="ingest-metrics", schema="ingest-metrics"
+    )
     consumer.add_step(
         MapStep(
             route=empty_route,
@@ -130,7 +132,9 @@ def test_broadcast(
     contain a Broadcast.
     """
 
-    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics", schema=SCHEMA)
+    consumer = ArroyoConsumer(
+        source="source1", stream_name="ingest-metrics", schema="ingest-metrics"
+    )
     consumer.add_step(
         MapStep(
             route=Route(source="source1", waypoints=[]),
@@ -218,7 +222,9 @@ def test_multiple_routes(
     contain branching routes.
     """
 
-    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics", schema=SCHEMA)
+    consumer = ArroyoConsumer(
+        source="source1", stream_name="ingest-metrics", schema="ingest-metrics"
+    )
     consumer.add_step(
         MapStep(
             route=Route(source="source1", waypoints=[]),
@@ -311,7 +317,9 @@ def test_standard_reduce(
     and offset management strategy
     """
 
-    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics", schema=SCHEMA)
+    consumer = ArroyoConsumer(
+        source="source1", stream_name="ingest-metrics", schema="ingest-metrics"
+    )
     consumer.add_step(
         MapStep(
             route=Route(source="source1", waypoints=[]),
@@ -513,7 +521,9 @@ def test_reduce_with_gap(
     and offset management strategy
     """
 
-    consumer = ArroyoConsumer(source="source1", stream_name="ingest-metrics", schema=SCHEMA)
+    consumer = ArroyoConsumer(
+        source="source1", stream_name="ingest-metrics", schema="ingest-metrics"
+    )
     consumer.add_step(
         MapStep(
             route=Route(source="source1", waypoints=[]),

--- a/sentry_streams/tests/adapters/arroyo/test_delegate.py
+++ b/sentry_streams/tests/adapters/arroyo/test_delegate.py
@@ -7,13 +7,13 @@ from sentry_streams.adapters.arroyo.rust_step import (
     Committable,
     SingleMessageOperatorDelegate,
 )
-from sentry_streams.pipeline.message import Message
+from sentry_streams.pipeline.message import Message, PyMessage
 
 
 class SingleMessageTransformer(SingleMessageOperatorDelegate[str, str]):
     def _process_message(self, msg: Message[str], committable: Committable) -> Message[str] | None:
         if msg.payload == "process":
-            return Message("processed", msg.headers, msg.timestamp, msg.schema)
+            return PyMessage("processed", msg.headers, msg.timestamp, msg.schema)
         if msg.payload == "filter":
             return None
         else:
@@ -23,7 +23,7 @@ class SingleMessageTransformer(SingleMessageOperatorDelegate[str, str]):
 
 def test_rust_step() -> None:
     def make_msg(payload: str) -> Message[str]:
-        return Message(
+        return PyMessage(
             payload=payload, headers=[("head", "val".encode())], timestamp=0, schema=None
         )
 

--- a/sentry_streams/tests/adapters/arroyo/test_forwarder.py
+++ b/sentry_streams/tests/adapters/arroyo/test_forwarder.py
@@ -12,7 +12,7 @@ from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 
 from sentry_streams.adapters.arroyo.forwarder import Forwarder
 from sentry_streams.adapters.arroyo.routes import Route, RoutedValue
-from sentry_streams.pipeline.message import Message as StreamsMessage
+from sentry_streams.pipeline.message import PyMessage as StreamsMessage
 from tests.adapters.arroyo.message_helpers import make_msg
 
 

--- a/sentry_streams/tests/adapters/arroyo/test_steps.py
+++ b/sentry_streams/tests/adapters/arroyo/test_steps.py
@@ -29,7 +29,7 @@ from sentry_streams.adapters.arroyo.steps import (
     StreamSinkStep,
 )
 from sentry_streams.examples.transformer import TransformerBatch
-from sentry_streams.pipeline.message import Message as StreamsMessage
+from sentry_streams.pipeline.message import PyMessage as StreamsMessage
 from sentry_streams.pipeline.pipeline import (
     Aggregate,
     Branch,


### PR DESCRIPTION
This is the foundation of the work to manage Message structures in Rust.
There is a more refactoring  work to do to have a proper Rust Message abstraciton
though this is step one we can build on top of.

We are trying to move more streaming processing logic to Rust (for efficiency).
At the same time, we want to build Python streaming application,
Rust streaming application and hybrid streaming application where some
steps are in Python and some are in Rust.

The requirement above imply both Rust and Python must understand the Message
data structure, thus this has to be defined in Rust and exposed via Pyo3.
Rust orchestrate the pipeline. As such it will create the message instance
after the consumer. 

Having both Rust and Python streaming steps means we need multiple types of
messages (we cannot use generics as we cannot expose to python a rust generic
structure). Different message types will be able to be processed by some 
operators and not by others. 

Having oth rust code and python code processing the same message means the
message msut be able to move in and out of the Python memory otherwise 
Rust has to take the Gil every time it needs to read the content of the message.

This PR starts addressing some of the problems above:
- Moves the Message class from PYthon to Rust and introduces two message
  types: PyAny and Bytes Array. This allows us to change all the Rust
  steps interface to manage a message they can understand rather than an
  opaque PyAny.
- Provides some transformation function to copy messages in and out of
  Python memory so the same message can be handed over to Python and back
  thus being processable through hybrid pipelines. (source and sink being 
  Rust means all pipelines are hybrid already). This opens the door to
  more Rust native steps. Transformation requires copy so it is not the
  most effiient way. Though there are ways to optimize this going on.
- Introduces a wrapper in Python to give Python code the illusion that the
  Message is generic with respect to the payload type. This cannot be done
  with a Rust generic.
- Replaces the usage of the old Message class in Python code and adapts the
   usage of the schema.


Next steps on top of this (see the TODOs in `messages.rs`).
- Remove copy paste. Create the hierarchy of messages as an Enum in Rust
- Introduce a unified transformation layer between Python and Rust so
  we can optimize translation by reducing copy.
- Create two variants of the same message to make it available to both
  Rust and Python.
