### PR TITLE
Support Reduce in the Rust Adapter as a Python delegate

### DIFF
--- a/sentry_streams/sentry_streams/adapters/arroyo/reduce_delegate.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/reduce_delegate.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import time
+from datetime import datetime
+from typing import (
+    Any,
+    Generic,
+    Iterable,
+    MutableSequence,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
+
+from arroyo.processing.strategies.abstract import ProcessingStrategy
+from arroyo.types import FilteredPayload
+from arroyo.types import Message as ArroyoMessage
+from arroyo.types import Partition, Topic, Value
+
+from sentry_streams.adapters.arroyo.reduce import build_arroyo_windowed_reduce
+from sentry_streams.adapters.arroyo.routes import Route, RoutedValue
+from sentry_streams.adapters.arroyo.rust_step import (
+    Committable,
+    RustOperatorDelegate,
+    RustOperatorFactory,
+)
+from sentry_streams.pipeline.message import Message, PyMessage
+from sentry_streams.pipeline.pipeline import Reduce
+
+TIn = TypeVar("TIn")
+TOut = TypeVar("TOut")
+
+
+class OutputRetriever(ProcessingStrategy[Union[FilteredPayload, TIn]]):
+    """ """
+
+    def __init__(
+        self,
+    ) -> None:
+        self.__pending_messages: MutableSequence[Tuple[Message[TIn], Committable]] = []
+
+    def submit(self, message: ArroyoMessage[Union[FilteredPayload, TIn]]) -> None:
+        if isinstance(message.payload, FilteredPayload):
+            return
+        else:
+            if isinstance(message.payload, RoutedValue):
+                payload: Any = message.payload.payload
+            else:
+                payload = message.payload
+
+            timestamp = (
+                message.timestamp.timestamp() if message.timestamp is not None else time.time()
+            )
+            msg = PyMessage(
+                payload=payload,
+                headers=[],
+                timestamp=timestamp,
+                schema=None,
+            )
+
+            committable = {
+                (partition.topic.name, partition.index): offset
+                for partition, offset in message.committable.items()
+            }
+
+            self.__pending_messages.append((msg, committable))
+
+    def poll(self) -> None:
+        pass
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    def terminate(self) -> None:
+        pass
+
+    def fetch(self) -> Iterable[Tuple[Message[TIn], Committable]]:
+        """
+        Fetches the output messages from the processing strategy.
+        This method is a placeholder and should be implemented to return
+        the actual output messages.
+        """
+        ret = self.__pending_messages
+        self.__pending_messages = []
+        return ret
+
+
+class ReduceDelegateFactory(RustOperatorFactory[TIn, TOut], Generic[TIn, TOut]):
+
+    def __init__(self, step: Reduce[Any, Any, Any]) -> None:
+        super().__init__()
+        self.__step = step
+
+    def build(self) -> ReduceDelegate[TIn, TOut]:
+        retriever = OutputRetriever[TOut]()
+        route = Route(source="dummy", waypoints=[])
+
+        return ReduceDelegate(
+            build_arroyo_windowed_reduce(
+                self.__step.windowing,
+                self.__step.aggregate_fn,
+                retriever,
+                route,
+            ),
+            retriever,
+            route,
+        )
+
+
+class ReduceDelegate(RustOperatorDelegate[TIn, TOut], Generic[TIn, TOut]):
+
+    def __init__(
+        self,
+        inner: ProcessingStrategy[Union[FilteredPayload, Any]],
+        output_retriever: OutputRetriever[TOut],
+        route: Route,
+    ) -> None:
+        super().__init__()
+        self.__inner = inner
+        self.__retriever = output_retriever
+        self.__route = route
+
+    def submit(self, message: Message[TIn], committable: Committable) -> None:
+        arroyo_committable = {
+            Partition(Topic(partition[0]), partition[1]): offset
+            for partition, offset in committable.items()
+        }
+        msg = ArroyoMessage(
+            Value(
+                RoutedValue(self.__route, message),
+                arroyo_committable,
+                datetime.fromtimestamp(message.timestamp) if message.timestamp else None,
+            )
+        )
+        self.__inner.submit(msg)
+
+    def poll(self) -> Iterable[Tuple[Message[TOut], Committable]]:
+        self.__inner.poll()
+        return self.__retriever.fetch()
+
+    def flush(self, timeout: float | None = None) -> Iterable[Tuple[Message[TOut], Committable]]:
+        self.__inner.join(timeout)
+        ret = self.__retriever.fetch()
+        self.__inner.close()
+        return ret

--- a/sentry_streams/sentry_streams/adapters/arroyo/reduce_delegate.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/reduce_delegate.py
@@ -140,10 +140,11 @@ class ReduceDelegate(RustOperatorDelegate[TIn, TOut], Generic[TIn, TOut]):
 
     def poll(self) -> Iterable[Tuple[Message[TOut], Committable]]:
         self.__inner.poll()
-        return self.__retriever.fetch()
+        ret = [(msg.to_inner(), committable) for msg, committable in self.__retriever.fetch()]
+        return ret
 
     def flush(self, timeout: float | None = None) -> Iterable[Tuple[Message[TOut], Committable]]:
         self.__inner.join(timeout)
-        ret = self.__retriever.fetch()
+        ret = [(msg.to_inner(), committable) for msg, committable in self.__retriever.fetch()]
         self.__inner.close()
         return ret

--- a/sentry_streams/sentry_streams/adapters/arroyo/reduce_delegate.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/reduce_delegate.py
@@ -33,7 +33,19 @@ TOut = TypeVar("TOut")
 
 
 class OutputRetriever(ProcessingStrategy[Union[FilteredPayload, TIn]]):
-    """ """
+    """
+    This is an Arroyo strategy to be wired to another strategy used inside
+    a `RustOperatorDelegate`. This strategy collects the result and return it to the
+    Rust code.
+
+    Arroyo strategies are provided the following step and are expected to
+    hand the result directly to it. This does not work for `RustOperatorDelegate`
+    which is expected to return the result as return value of poll and flush.
+
+    In order to wrap an existing Arroyo strategy in a `RustOperatorDelegate` we
+    need to provide an instance of this class to the existing strategy to
+    collect the results and send it them back to Rust as `poll` return value.
+    """
 
     def __init__(
         self,
@@ -41,6 +53,13 @@ class OutputRetriever(ProcessingStrategy[Union[FilteredPayload, TIn]]):
         self.__pending_messages: MutableSequence[Tuple[Message[TIn], Committable]] = []
 
     def submit(self, message: ArroyoMessage[Union[FilteredPayload, TIn]]) -> None:
+        """
+        Accumulates messages provided by the previous step in the consumer.
+
+        Different types of reducers can provide RoutedValues or bare aggregated
+        data. So this class has to support both.
+        Messages are turned into `PyMessage` and stored in this format.
+        """
         if isinstance(message.payload, FilteredPayload):
             return
         else:
@@ -81,8 +100,6 @@ class OutputRetriever(ProcessingStrategy[Union[FilteredPayload, TIn]]):
     def fetch(self) -> Iterable[Tuple[Message[TIn], Committable]]:
         """
         Fetches the output messages from the processing strategy.
-        This method is a placeholder and should be implemented to return
-        the actual output messages.
         """
         ret = self.__pending_messages
         self.__pending_messages = []
@@ -90,6 +107,9 @@ class OutputRetriever(ProcessingStrategy[Union[FilteredPayload, TIn]]):
 
 
 class ReduceDelegateFactory(RustOperatorFactory[TIn, TOut], Generic[TIn, TOut]):
+    """
+    Creates a `ReduceDelegate`. This is the class to provide to the Rust runtime.
+    """
 
     def __init__(self, step: Reduce[Any, Any, Any]) -> None:
         super().__init__()
@@ -112,6 +132,17 @@ class ReduceDelegateFactory(RustOperatorFactory[TIn, TOut], Generic[TIn, TOut]):
 
 
 class ReduceDelegate(RustOperatorDelegate[TIn, TOut], Generic[TIn, TOut]):
+    """
+    Wraps the various types of Python Reduce steps to be used by the
+    Rust runtime. Eventually we will move the reduce logic itself to Rust.
+
+    It receives the messages to add to the accumulator with the `submit` method.
+    These messages are directly forwarded to the Reduce strategy after
+    turning them into `RoutedValue`.
+
+    Extracts the results from `OutputRetriever` after polling on the Reduce
+    strategy.
+    """
 
     def __init__(
         self,
@@ -131,6 +162,8 @@ class ReduceDelegate(RustOperatorDelegate[TIn, TOut], Generic[TIn, TOut]):
         }
         msg = ArroyoMessage(
             Value(
+                # TODO: Stop creating a `RoutedValue` and make the Reduce strategy
+                # accept `Message` directly.
                 RoutedValue(self.__route, message),
                 arroyo_committable,
                 datetime.fromtimestamp(message.timestamp) if message.timestamp else None,

--- a/sentry_streams/sentry_streams/adapters/arroyo/rust_arroyo.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/rust_arroyo.py
@@ -10,6 +10,7 @@ from typing import (
     cast,
 )
 
+from sentry_streams.adapters.arroyo.reduce_delegate import ReduceDelegateFactory
 from sentry_streams.adapters.arroyo.routers import build_branches
 from sentry_streams.adapters.arroyo.routes import Route
 from sentry_streams.adapters.stream_adapter import PipelineConfig, StreamAdapter
@@ -229,7 +230,11 @@ class RustArroyoAdapter(StreamAdapter[Route, Route]):
         Build a reduce operator for the platform the adapter supports.
         """
 
-        raise NotImplementedError
+        route = RustRoute(stream.source, stream.waypoints)
+        self.__consumers[stream.source].add_step(
+            RuntimeOperator.PythonAdapter(route, ReduceDelegateFactory(step))
+        )
+        return stream
 
     def broadcast(
         self,

--- a/sentry_streams/sentry_streams/adapters/arroyo/rust_step.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/rust_step.py
@@ -25,12 +25,16 @@ class RustOperatorDelegate(ABC, Generic[TIn, TOut]):
     streaming platform operators in Python and wire them up to the
     Rust Streaming Adapter.
 
-    The `RuntimeOperator::PythonAdapter` creates a Rust Arroyo processing
-    strategy that, instead of performing its work in Rust, delegates
-    submit and poll to the python class that implements this interface.
-
-    Eventually all steps should be moved to Rust but this class facilitates
-    the migration. It also facilitates quick prototyping.
+    This delegate runs in a Rust Arroyo strategy which delegates message
+    processing to instances of this class following this process:
+    1. The rust strategy receives a message via `submit`
+    2. The rust strategy forwards the message to the delegate (the instance
+       of this class), which takes it over.
+    3. The StreamingProcessor calls `poll` on the Rust Arroyo strategy.
+    4. The rust strategy calls poll on the delegate that may or may
+       not return processed messages.
+    5. If the delegate returns messages, the Rust strategy forwards them
+       to the Arroyo next step.
 
     This class does not provides exactly the same Arroyo strategy
     interface. Instead it provides something easier to manage in Rust.

--- a/sentry_streams/sentry_streams/examples/simple_batching.py
+++ b/sentry_streams/sentry_streams/examples/simple_batching.py
@@ -1,0 +1,17 @@
+from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
+
+from sentry_streams.pipeline import Batch, streaming_source
+from sentry_streams.pipeline.chain import Parser, Serializer
+
+pipeline = streaming_source(
+    name="myinput",
+    stream_name="ingest-metrics",
+)
+
+# TODO: Figure out why the concrete type of InputType is not showing up in the type hint of chain1
+chain1 = (
+    pipeline.apply("parser", Parser(msg_type=IngestMetric))
+    .apply("mybatch", Batch(batch_size=3))
+    .apply("serializer", Serializer())
+    .sink("mysink", stream_name="transformed-events")
+)  # flush the batches to the Sink

--- a/sentry_streams/sentry_streams/examples/simple_batching.py
+++ b/sentry_streams/sentry_streams/examples/simple_batching.py
@@ -1,7 +1,7 @@
 from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 
 from sentry_streams.pipeline import Batch, streaming_source
-from sentry_streams.pipeline.chain import Parser, Serializer
+from sentry_streams.pipeline.chain import Parser, Serializer, StreamSink
 
 pipeline = streaming_source(
     name="myinput",
@@ -13,5 +13,5 @@ chain1 = (
     pipeline.apply("parser", Parser(msg_type=IngestMetric))
     .apply("mybatch", Batch(batch_size=3))
     .apply("serializer", Serializer())
-    .sink("mysink", stream_name="transformed-events")
+    .sink("mysink", StreamSink(stream_name="transformed-events"))
 )  # flush the batches to the Sink

--- a/sentry_streams/sentry_streams/pipeline/message.py
+++ b/sentry_streams/sentry_streams/pipeline/message.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import Generic, Optional, Sequence, Tuple, TypeVar, cast
+from typing import Any, Generic, Optional, Sequence, Tuple, TypeVar, cast
 
 from sentry_streams.rust_streams import PyAnyMessage, RawMessage
 
@@ -49,6 +49,10 @@ class Message(ABC, Generic[TPayload]):
 
     @abstractmethod
     def deepcopy(self) -> Message[TPayload]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def to_inner(self) -> Any:
         raise NotImplementedError
 
     def __eq__(self, other: object) -> bool:
@@ -101,10 +105,13 @@ class PyMessage(Generic[TPayload], Message[TPayload]):
         return self.inner.schema
 
     def __repr__(self) -> str:
-        return self.inner.__repr__()
+        return f"PyMessage({self.inner.__repr__()})"
 
     def __str__(self) -> str:
         return self.inner.__str__()
+
+    def to_inner(self) -> Any:
+        return self.inner
 
     def deepcopy(self) -> PyMessage[TPayload]:
         return PyMessage(
@@ -146,10 +153,13 @@ class PyRawMessage(Message[bytes]):
         return self.inner.schema
 
     def __repr__(self) -> str:
-        return self.inner.__repr__()
+        return f"RawMessage({self.inner.__repr__()})"
 
     def __str__(self) -> str:
         return self.inner.__str__()
+
+    def to_inner(self) -> Any:
+        return self.inner
 
     def deepcopy(self) -> PyRawMessage:
         return PyRawMessage(

--- a/sentry_streams/sentry_streams/pipeline/message.py
+++ b/sentry_streams/sentry_streams/pipeline/message.py
@@ -100,6 +100,12 @@ class PyMessage(Generic[TPayload], Message[TPayload]):
     def schema(self) -> str | None:
         return self.inner.schema
 
+    def __repr__(self) -> str:
+        return self.inner.__repr__()
+
+    def __str__(self) -> str:
+        return self.inner.__str__()
+
     def deepcopy(self) -> PyMessage[TPayload]:
         return PyMessage(
             deepcopy(self.inner.payload),
@@ -138,6 +144,12 @@ class PyRawMessage(Message[bytes]):
     @property
     def schema(self) -> str | None:
         return self.inner.schema
+
+    def __repr__(self) -> str:
+        return self.inner.__repr__()
+
+    def __str__(self) -> str:
+        return self.inner.__str__()
 
     def deepcopy(self) -> PyRawMessage:
         return PyRawMessage(

--- a/sentry_streams/src/messages.rs
+++ b/sentry_streams/src/messages.rs
@@ -264,9 +264,10 @@ impl Into<PyStreamingMessage> for Py<PyAny> {
                     content: content.clone().unbind(),
                 })
             } else {
-                Err(pyo3::exceptions::PyTypeError::new_err(
-                    "Message type is invalid",
-                ))
+                Err(pyo3::exceptions::PyTypeError::new_err(format!(
+                    "Message type is invalid: expected PyAnyMessage or RawMessage, got {}",
+                    bound.get_type().name().unwrap()
+                )))
             }
         })
         .unwrap()

--- a/sentry_streams/tests/adapters/arroyo/test_reduce_delegate.py
+++ b/sentry_streams/tests/adapters/arroyo/test_reduce_delegate.py
@@ -1,0 +1,212 @@
+from datetime import datetime
+from typing import MutableSequence, Optional, Sequence, Tuple, Union
+
+from arroyo.processing.strategies.abstract import ProcessingStrategy
+from arroyo.types import FilteredPayload
+from arroyo.types import Message as ArroyoMessage
+from arroyo.types import Partition, Topic, Value
+
+from sentry_streams.adapters.arroyo.reduce_delegate import (
+    OutputRetriever,
+    ReduceDelegate,
+    ReduceDelegateFactory,
+)
+from sentry_streams.adapters.arroyo.routes import Route, RoutedValue
+from sentry_streams.adapters.arroyo.rust_step import Committable
+from sentry_streams.pipeline.chain import ExtensibleChain
+from sentry_streams.pipeline.message import Message, PyMessage
+from sentry_streams.pipeline.pipeline import Batch
+
+
+def test_retriever() -> None:
+    retriever = OutputRetriever[str]()
+
+    timestamp = datetime.now()
+    retriever.submit(
+        ArroyoMessage(
+            Value("payload", {Partition(Topic("test_topic"), 0): 100}, timestamp),
+        )
+    )
+    retriever.submit(
+        ArroyoMessage(
+            Value("payload2", {Partition(Topic("test_topic"), 0): 200}, timestamp),
+        )
+    )
+    output = list(retriever.fetch())
+
+    assert len(output) == 2
+
+    assert output[0][0] == PyMessage(
+        payload="payload",
+        headers=[],
+        timestamp=timestamp.timestamp(),
+        schema=None,
+    )
+    assert output[0][1] == {("test_topic", 0): 100}
+
+    assert output[1][0] == PyMessage(
+        payload="payload2",
+        headers=[],
+        timestamp=timestamp.timestamp(),
+        schema=None,
+    )
+    assert output[1][1] == {("test_topic", 0): 200}
+
+
+class FakeReducer(ProcessingStrategy[Union[FilteredPayload, RoutedValue]]):
+    def __init__(self, next: ProcessingStrategy[Sequence[Message[str]]]) -> None:
+        self.__messages: MutableSequence[Message[str]] = []
+        self.__next = next
+
+    def submit(self, message: ArroyoMessage[Union[FilteredPayload, RoutedValue]]) -> None:
+        if isinstance(message.payload, FilteredPayload):
+            return
+        self.__messages.append(message.payload.payload)
+
+    def _flush(self) -> None:
+        self.__next.submit(
+            ArroyoMessage(
+                Value(
+                    self.__messages,
+                    {Partition(Topic("test_topic"), 0): 400},
+                    timestamp=datetime.fromtimestamp(self.__messages[0].timestamp),
+                ),
+            )
+        )
+        self.__messages = []
+
+    def poll(self) -> None:
+        if len(self.__messages) > 2:
+            # Simulate a batch of messages being processed
+            self._flush()
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        self._flush()
+        self.__next.join(timeout)
+
+    def close(self) -> None:
+        self.__next.close()
+
+    def terminate(self) -> None:
+        self.__next.terminate()
+
+
+def build_msg(payload: str, timestamp: float, offset: int) -> Tuple[PyMessage[str], Committable]:
+    return (
+        PyMessage(
+            payload=payload,
+            headers=[],
+            timestamp=timestamp,
+            schema=None,
+        ),
+        {("test_topic", 0): offset},
+    )
+
+
+def test_reduce_poll() -> None:
+    retriever = OutputRetriever[Sequence[Message[str]]]()
+    reducer = FakeReducer(retriever)
+
+    delegate = ReduceDelegate[str, Sequence[Message[str]]](
+        reducer,
+        retriever,
+        Route("test_route", []),
+    )
+
+    timestamp = datetime.now().timestamp()
+    # Simulate the reducer processing messages
+    delegate.submit(
+        *build_msg("message1", timestamp, 100),
+    )
+    assert len(list(delegate.poll())) == 0
+
+    delegate.submit(
+        *build_msg("message2", timestamp, 200),
+    )
+    assert len(list(delegate.poll())) == 0
+
+    delegate.submit(
+        *build_msg("message3", timestamp, 300),
+    )
+
+    # Poll to trigger processing
+    batch = list(delegate.poll())
+    assert batch == [
+        (
+            PyMessage(
+                payload=[
+                    build_msg("message1", timestamp, 100)[0],
+                    build_msg("message2", timestamp, 200)[0],
+                    build_msg("message3", timestamp, 300)[0],
+                ],
+                headers=[],
+                timestamp=timestamp,
+                schema=None,
+            ),
+            {("test_topic", 0): 400},
+        )
+    ]
+    assert len(list(delegate.poll())) == 0
+    assert len(list(retriever.fetch())) == 0
+
+
+def test_flush() -> None:
+    retriever = OutputRetriever[Sequence[Message[str]]]()
+    reducer = FakeReducer(retriever)
+
+    delegate = ReduceDelegate[str, Sequence[Message[str]]](
+        reducer,
+        retriever,
+        Route("test_route", []),
+    )
+
+    timestamp = datetime.now().timestamp()
+    # Simulate the reducer processing messages
+    delegate.submit(
+        *build_msg("message1", timestamp, 100),
+    )
+    batch = list(delegate.flush())
+    assert batch == [
+        (
+            PyMessage(
+                payload=[
+                    build_msg("message1", timestamp, 100)[0],
+                ],
+                headers=[],
+                timestamp=timestamp,
+                schema=None,
+            ),
+            {("test_topic", 0): 400},
+        )
+    ]
+    assert len(list(delegate.poll())) == 0
+
+
+def test_reduce() -> None:
+    pipeline: ExtensibleChain[Message[bytes]] = ExtensibleChain("root")
+    factory = ReduceDelegateFactory[str, Sequence[str]](Batch("batch", pipeline, [], 2))
+    delegate = factory.build()
+
+    timestamp = datetime.now().timestamp()
+    # Simulate the reducer processing messages
+    delegate.submit(
+        *build_msg("message1", timestamp, 100),
+    )
+    assert len(list(delegate.poll())) == 0
+
+    delegate.submit(
+        *build_msg("message2", timestamp, 200),
+    )
+
+    batch = list(delegate.poll())
+    assert batch == [
+        (
+            PyMessage(
+                payload=["message1", "message2"],
+                headers=[],
+                timestamp=timestamp,
+                schema=None,
+            ),
+            {("test_topic", 0): 200},
+        )
+    ]


### PR DESCRIPTION
Based on https://github.com/getsentry/streams/pull/118

This uses the `RustOperatorDelegate` to make the Python Reduce step
working on the Rust Adapter.

We create the reduce step as an Arroyo Python strategy just like in the
Python adapter. Then we wire an `OutputRetriever` as following step.
This is used to colelct the result.
The above is then wrapped into the `ReduceDelegate` which extends
`RustOperatorDelegate`, which is thus manageable by the Rust runtime.
   
