### PR TITLE
Add extension-module to the MacOSx build

### DIFF
--- a/.github/workflows/build-streams.yaml
+++ b/.github/workflows/build-streams.yaml
@@ -74,7 +74,7 @@ jobs:
         uses: PyO3/maturin-action@aef21716ff3dcae8a1c301d23ec3e4446972a6e3
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist --find-interpreter --features=extension-module
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           working-directory: ./sentry_streams
           docker-options:

--- a/sentry_streams/uv.lock
+++ b/sentry_streams/uv.lock
@@ -748,7 +748,7 @@ wheels = [
 
 [[package]]
 name = "sentry-streams"
-version = "0.0.18"
+version = "0.0.19"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
https://github.com/getsentry/streams/pull/113 disabled extension-module but 
not on the MacOSX build.
