### PR TITLE
quick-fix: Ensure schema is retained after a batching step

### DIFF
--- a/sentry_streams/sentry_streams/adapters/arroyo/reduce_delegate.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/reduce_delegate.py
@@ -11,6 +11,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from arroyo.processing.strategies.abstract import ProcessingStrategy
@@ -165,6 +166,7 @@ class OutputRetriever(ProcessingStrategy[Union[FilteredPayload, TIn]]):
             return
         else:
             if isinstance(message.payload, RoutedValue):
+                # this is the actual raw payload
                 payload: Any = message.payload.payload
             else:
                 payload = message.payload
@@ -172,19 +174,28 @@ class OutputRetriever(ProcessingStrategy[Union[FilteredPayload, TIn]]):
             timestamp = (
                 message.timestamp.timestamp() if message.timestamp is not None else time.time()
             )
-            msg = PyMessage(
-                payload=payload,
-                headers=[],
-                timestamp=timestamp,
-                schema=None,
-            )
+
+            if isinstance(payload, MutableSequence) and isinstance(payload[0], tuple):
+                msg = PyMessage(
+                    payload=payload,
+                    headers=[],
+                    timestamp=timestamp,
+                    schema=payload[0][1],
+                )
+            else:
+                msg = PyMessage(
+                    payload=payload,
+                    headers=[],
+                    timestamp=timestamp,
+                    schema=None,
+                )
 
             committable = {
                 (partition.topic.name, partition.index): offset
                 for partition, offset in message.committable.items()
             }
 
-            self.__pending_messages.append((msg, committable))
+            self.__pending_messages.append((cast(Message[TIn], msg), committable))
 
     def poll(self) -> None:
         pass

--- a/sentry_streams/sentry_streams/adapters/arroyo/reduce_delegate.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/reduce_delegate.py
@@ -8,6 +8,7 @@ from typing import (
     Iterable,
     MutableSequence,
     Optional,
+    Sequence,
     Tuple,
     TypeVar,
     Union,
@@ -175,7 +176,7 @@ class OutputRetriever(ProcessingStrategy[Union[FilteredPayload, TIn]]):
                 message.timestamp.timestamp() if message.timestamp is not None else time.time()
             )
 
-            if isinstance(payload, MutableSequence) and isinstance(payload[0], tuple):
+            if isinstance(payload, Sequence) and isinstance(payload[0], tuple):
                 batch = []
                 schema = None
                 for tup in payload:

--- a/sentry_streams/sentry_streams/adapters/arroyo/reduce_delegate.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/reduce_delegate.py
@@ -176,11 +176,18 @@ class OutputRetriever(ProcessingStrategy[Union[FilteredPayload, TIn]]):
             )
 
             if isinstance(payload, MutableSequence) and isinstance(payload[0], tuple):
+                batch = []
+                schema = None
+                for tup in payload:
+                    batch.append(tup[0])
+
+                schema = payload[0][1]
+
                 msg = PyMessage(
-                    payload=payload,
+                    payload=batch,
                     headers=[],
                     timestamp=timestamp,
-                    schema=payload[0][1],
+                    schema=schema,
                 )
             else:
                 msg = PyMessage(

--- a/sentry_streams/sentry_streams/examples/batching.py
+++ b/sentry_streams/sentry_streams/examples/batching.py
@@ -10,15 +10,15 @@ pipeline = streaming_source(
 )
 
 # TODO: Figure out why the concrete type of InputType is not showing up in the type hint of chain1
-chain1 = pipeline.apply("parser", Parser(msg_type=IngestMetric)).apply(
-    "mybatch", Batch(batch_size=5)
-)  # User simply provides the batch size
+parsed = pipeline.apply("parser", Parser(msg_type=IngestMetric))
 
-chain2 = chain1.apply(
+batched = parsed.apply("mybatch", Batch(batch_size=5))  # User simply provides the batch size
+
+unbatched = batched.apply(
     "myunbatch",
     FlatMap(function=unbatch),
 )
 
-chain3 = chain2.apply("serializer", Serializer()).sink(
+sinked = unbatched.apply("serializer", Serializer()).sink(
     "kafkasink2", StreamSink(stream_name="transformed-events")
 )  # flush the batches to the Sink

--- a/sentry_streams/sentry_streams/pipeline/batch.py
+++ b/sentry_streams/sentry_streams/pipeline/batch.py
@@ -1,12 +1,12 @@
-from typing import Any, Generator, MutableSequence, Optional, Self
-
-from sentry_kafka_schemas.codecs import Codec
+from typing import Generator, MutableSequence, Optional, Self, Tuple
 
 from sentry_streams.pipeline.function_template import Accumulator, InputType
 from sentry_streams.pipeline.message import Message
 
 
-class BatchBuilder(Accumulator[Message[InputType], MutableSequence[InputType]]):
+class BatchBuilder(
+    Accumulator[Message[InputType], MutableSequence[Tuple[InputType, Optional[str]]]]
+):
     """
     Takes a generic input format, and batches into a generic batch representation
     with the same input type. Returns this batch representation.
@@ -15,15 +15,14 @@ class BatchBuilder(Accumulator[Message[InputType], MutableSequence[InputType]]):
     """
 
     def __init__(self) -> None:
-        self.batch: MutableSequence[InputType] = []
-        self.schema: Optional[Codec[Any]] = None
+        self.batch: MutableSequence[Tuple[InputType, Optional[str]]] = []
 
     def add(self, value: Message[InputType]) -> Self:
-        self.batch.append(value.payload)
+        self.batch.append((value.payload, value.schema))
 
         return self
 
-    def get_value(self) -> MutableSequence[InputType]:
+    def get_value(self) -> MutableSequence[Tuple[InputType, Optional[str]]]:
         return self.batch
 
     def merge(self, other: Self) -> Self:
@@ -33,7 +32,7 @@ class BatchBuilder(Accumulator[Message[InputType], MutableSequence[InputType]]):
 
 
 def unbatch(
-    batch: Message[MutableSequence[InputType]],
+    batch: Message[MutableSequence[Tuple[InputType, Optional[str]]]],
 ) -> Generator[InputType, None, None]:
     """
     Takes in a generic batch representation, outputs a Generator type for iterating over
@@ -42,5 +41,5 @@ def unbatch(
     The data type of the elements remains the same through this operation. This operation
     may need to be followed by a Map or other transformation if a new output type is expected.
     """
-    for payload in batch.payload:
+    for payload, _ in batch.payload:
         yield payload

--- a/sentry_streams/sentry_streams/pipeline/chain.py
+++ b/sentry_streams/sentry_streams/pipeline/chain.py
@@ -165,7 +165,7 @@ class Serializer(Applier[Message[TIn], bytes], Generic[TIn]):
 
 @dataclass
 class Batch(
-    Applier[Message[InputType], Message[MutableSequence[InputType]]],
+    Applier[Message[InputType], Message[MutableSequence[Tuple[InputType, Optional[str]]]]],
     Generic[MeasurementUnit, InputType],
 ):
     batch_size: MeasurementUnit

--- a/sentry_streams/sentry_streams/pipeline/pipeline.py
+++ b/sentry_streams/sentry_streams/pipeline/pipeline.py
@@ -381,7 +381,7 @@ BatchInput = TypeVar("BatchInput")
 
 
 @dataclass
-class Batch(Reduce[MeasurementUnit, InputType, MutableSequence[InputType]]):
+class Batch(Reduce[MeasurementUnit, InputType, MutableSequence[Tuple[InputType, Optional[str]]]]):
     """
     A step to Batch up the results of the prior step.
 

--- a/sentry_streams/tests/adapters/arroyo/test_reduce_delegate.py
+++ b/sentry_streams/tests/adapters/arroyo/test_reduce_delegate.py
@@ -97,7 +97,7 @@ def build_msg(payload: str, timestamp: float, offset: int) -> Tuple[PyMessage[st
             payload=payload,
             headers=[],
             timestamp=timestamp,
-            schema=None,
+            schema="ingest-metrics",
         ),
         {("test_topic", 0): offset},
     )
@@ -221,10 +221,10 @@ def test_reduce() -> None:
     expected = [
         (
             PyMessage(
-                payload=[("message1", None), ("message2", None)],
+                payload=["message1", "message2"],
                 headers=[],
                 timestamp=timestamp,
-                schema=None,
+                schema="ingest-metrics",
             ).to_inner(),
             {("test_topic", 0): 200},
         )
@@ -233,4 +233,5 @@ def test_reduce() -> None:
     for i, msg1 in enumerate(batch):
         msg2 = expected[i]
         assert msg1[0].payload == msg2[0].payload, f"Payload mismatch at index {i}"
+        assert msg1[0].schema == msg2[0].schema, "Missing schema after batch"
         assert msg1[1] == msg2[1], f"Committable mismatch at index {i}"

--- a/sentry_streams/tests/adapters/arroyo/test_reduce_delegate.py
+++ b/sentry_streams/tests/adapters/arroyo/test_reduce_delegate.py
@@ -221,7 +221,7 @@ def test_reduce() -> None:
     expected = [
         (
             PyMessage(
-                payload=["message1", "message2"],
+                payload=[("message1", None), ("message2", None)],
                 headers=[],
                 timestamp=timestamp,
                 schema=None,

--- a/sentry_streams/uv.lock
+++ b/sentry_streams/uv.lock
@@ -748,7 +748,7 @@ wheels = [
 
 [[package]]
 name = "sentry-streams"
-version = "0.0.19"
+version = "0.0.20"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
A really simple way to unblock the work where a batching step happens before parsing. I can also introduce the concept of `Schema` in this PR, where we have an enum of all the allowed schemas / topic names. 

We should not stick with this in the long term, and likely enforce all Accumulators/Reduce steps to output a `Tuple[MutableSequence[InputType], Schema]`. Making this is a more significant typing change as it involves making sure primitives like `FlatMap` are also able to handle that output type. 