### PR TITLE
add cargo fmt to precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,15 @@ repos:
         name: isort (python)
         files: ^sentry_flink/.+
         args: [--settings-path=./sentry_flink/pyproject.toml]
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: format rust code
+        language: system
+        # keep in sync with Cargo.toml. There is no way to run cargo fmt for specific files
+        # https://github.com/rust-lang/rustfmt/issues/4485
+        entry: rustfmt --edition 2021
+        files: ^sentry-streams/.*\.rs$
 
 default_language_version:
   python: python3.11


### PR DESCRIPTION
This PR adds `rustup fmt` to run as a part of our pre-commit.
I ripped this from the arroyo repo pre-commit config: https://github.com/getsentry/arroyo/blob/main/.pre-commit-config.yaml#L35-L43