### PR TITLE
feat(api): Allow the Pipeline to have a chain API

### DIFF
--- a/sentry_streams/sentry_streams/examples/simple_map_filter.py
+++ b/sentry_streams/sentry_streams/examples/simple_map_filter.py
@@ -12,9 +12,8 @@ from sentry_streams.pipeline.pipeline import (
     GCSSink,
     Map,
     Parser,
-    Pipeline,
     Serializer,
-    StreamSource,
+    streaming_source,
 )
 
 
@@ -29,15 +28,10 @@ def generate_files() -> str:
     return f"file_{cur_time}.txt"
 
 
-pipeline = (
-    Pipeline()
-    .start(
-        StreamSource(
-            name="myinput",
-            stream_name="ingest-metrics",
-        )
-    )
-    .apply(Parser("parser", msg_type=IngestMetric))
+pipeline = streaming_source(name="myinput", stream_name="ingest-metrics")
+
+(
+    pipeline.apply(Parser("parser", msg_type=IngestMetric))
     .apply(Filter("filter", function=filter_events))
     .apply(Map("transform", function=transform_msg))
     .apply(Serializer("serializer"))

--- a/sentry_streams/sentry_streams/examples/simple_map_filter.py
+++ b/sentry_streams/sentry_streams/examples/simple_map_filter.py
@@ -3,9 +3,19 @@ from datetime import datetime
 from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 
 from sentry_streams.examples.transform_metrics import transform_msg
-from sentry_streams.pipeline import Filter, Map, Parser, Serializer, streaming_source
-from sentry_streams.pipeline.chain import GCSSink
+
+# from sentry_streams.pipeline import Filter, Map, Parser, Serializer, streaming_source
+# from sentry_streams.pipeline.chain import GCSSink
 from sentry_streams.pipeline.message import Message
+from sentry_streams.pipeline.pipeline import (
+    Filter,
+    GCSSink,
+    Map,
+    Parser,
+    Pipeline,
+    Serializer,
+    StreamSource,
+)
 
 
 def filter_events(msg: Message[IngestMetric]) -> bool:
@@ -19,20 +29,23 @@ def generate_files() -> str:
     return f"file_{cur_time}.txt"
 
 
-# A pipline with a few transformations
 pipeline = (
-    streaming_source(
-        name="myinput",
-        stream_name="ingest-metrics",
+    Pipeline()
+    .start(
+        StreamSource(
+            name="myinput",
+            stream_name="ingest-metrics",
+        )
     )
-    .apply(
-        "parser",
-        Parser(
-            msg_type=IngestMetric,
-        ),
+    .apply(Parser("parser", msg_type=IngestMetric))
+    .apply(Filter("filter", function=filter_events))
+    .apply(Map("transform", function=transform_msg))
+    .apply(Serializer("serializer"))
+    .sink(
+        GCSSink(
+            "mysink",
+            bucket="arroyo-artifacts",
+            object_generator=generate_files,
+        )
     )
-    .apply("filter", Filter(function=filter_events))
-    .apply("transform", Map(function=transform_msg))
-    .apply("serializer", Serializer())
-    .sink("mysink", GCSSink(bucket="arroyo-artifacts", object_generator=generate_files))
 )

--- a/sentry_streams/sentry_streams/pipeline/pipeline.py
+++ b/sentry_streams/sentry_streams/pipeline/pipeline.py
@@ -151,11 +151,14 @@ class Pipeline:
         self.__previous_step = step
         return self
 
-    def sink(self, step: Sink) -> Pipeline:
+    def sink(self, step: Sink) -> None:
         assert self.__previous_step, "Cannot create a sink a step without starting first"
         step.register(self, self.__previous_step)
         self.__previous_step = None
-        return self
+
+
+def streaming_source(name: str, stream_name: str) -> Pipeline:
+    return Pipeline().start(StreamSource(name=name, stream_name=stream_name))
 
 
 @dataclass


### PR DESCRIPTION
This changes the Pipeline class to have a chain-style API. See simple_map_filter.py for an example
of how this looks.

In order to make this work, the Pipeline needs to be aware of the previous step so it can be passed
in as the input to the new step. Also, instead of the steps being registered when they are
instantiated, they are added to the pipeline manually.
