### PR TITLE
ref: Handle overrides in GCSSink from config

### DIFF
--- a/sentry_streams/sentry_streams/adapters/arroyo/rust_arroyo.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/rust_arroyo.py
@@ -167,14 +167,10 @@ class RustArroyoAdapter(StreamAdapter[Route, Route]):
                 bucket = (
                     step.bucket if not sink_config.get("bucket") else str(sink_config.get("bucket"))
                 )
-                object_generator = (
-                    step.object_generator
-                    if not sink_config.get("object_file")
-                    else lambda: str(sink_config.get("object_file"))
-                )
             else:
                 bucket = step.bucket
-                object_generator = step.object_generator
+
+            object_generator = step.object_generator
 
             self.__consumers[stream.source].add_step(
                 RuntimeOperator.GCSSink(route, bucket, object_generator)

--- a/sentry_streams/sentry_streams/adapters/arroyo/rust_arroyo.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/rust_arroyo.py
@@ -107,7 +107,7 @@ def build_kafka_producer_config(
     sink: str, steps_config: Mapping[str, StepConfig]
 ) -> PyKafkaProducerConfig:
     sink_config = steps_config.get(sink)
-    assert sink_config is not None, f"Config not provided for source {sink}"
+    assert sink_config is not None, f"Config not provided for StreamSink {sink}"
 
     producer_config = cast(KafkaProducerConfig, sink_config)
     return PyKafkaProducerConfig(
@@ -163,9 +163,23 @@ class RustArroyoAdapter(StreamAdapter[Route, Route]):
         route = RustRoute(stream.source, stream.waypoints)
 
         if isinstance(step, GCSSink):
+            if sink_config := self.steps_config.get(step.name):
+                bucket = (
+                    step.bucket if not sink_config.get("bucket") else str(sink_config.get("bucket"))
+                )
+                object_generator = (
+                    step.object_generator
+                    if not sink_config.get("object_file")
+                    else lambda: str(sink_config.get("object_file"))
+                )
+            else:
+                bucket = step.bucket
+                object_generator = step.object_generator
+
             self.__consumers[stream.source].add_step(
-                RuntimeOperator.GCSSink(route, step.bucket, step.object_generator)
+                RuntimeOperator.GCSSink(route, bucket, object_generator)
             )
+
         # Our fallback for now since there's no other Sink type
         else:
             assert isinstance(step, StreamSink)

--- a/sentry_streams/sentry_streams/deployment_config/simple_map_filter.yaml
+++ b/sentry_streams/sentry_streams/deployment_config/simple_map_filter.yaml
@@ -18,4 +18,3 @@ pipeline:
               batch_time: 0.2
         mysink:
           bucket: "arroyo-artifacts"
-          object_file: "hardcoded.txt"

--- a/sentry_streams/sentry_streams/deployment_config/simple_map_filter.yaml
+++ b/sentry_streams/sentry_streams/deployment_config/simple_map_filter.yaml
@@ -17,4 +17,5 @@ pipeline:
               batch_size: 1000
               batch_time: 0.2
         mysink:
-          bootstrap_servers: ["127.0.0.1:9092"]
+          bucket: "arroyo-artifacts"
+          object_file: "hardcoded.txt"

--- a/sentry_streams/sentry_streams/examples/simple_map_filter.py
+++ b/sentry_streams/sentry_streams/examples/simple_map_filter.py
@@ -34,5 +34,5 @@ pipeline = (
     .apply("filter", Filter(function=filter_events))
     .apply("transform", Map(function=transform_msg))
     .apply("serializer", Serializer())
-    .sink("mysink", GCSSink(bucket="arroyo-artifacts", object_generator=generate_files))
+    .sink("mysink", GCSSink(bucket="dummy-bucket", object_generator=generate_files))
 )


### PR DESCRIPTION
Addresses https://github.com/getsentry/streaming-planning/issues/182. GCS Sink takes 2 configuration parameters
- bucket name (is static)
- object file names (can be dynamically generated)

This PR adds support for handling any overrides that may be provided in the config file for a specific pipeline. The rule of thumb is that any params defined in the config file will override any params as defined in the pipeline. 