### PR TITLE
ref(rust): fixup clippy lint

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -20,6 +20,8 @@ jobs:
         working-directory: ./sentry_streams
       - run: cargo fmt --check
         working-directory: ./sentry_streams
+      - run: cargo clippy --no-deps --all-features
+        working-directory: ./sentry_streams
 
   test:
     name: "Tests"

--- a/sentry_streams/src/callers.rs
+++ b/sentry_streams/src/callers.rs
@@ -68,7 +68,7 @@ mod tests {
 
             let result = match message.payload().payload {
                 RoutedValuePayload::PyStreamingMessage(ref msg) => {
-                    call_python_function(&callable, &msg).unwrap()
+                    call_python_function(&callable, msg).unwrap()
                 }
                 RoutedValuePayload::WatermarkMessage(..) => unreachable!(),
             };

--- a/sentry_streams/src/gcs_writer.rs
+++ b/sentry_streams/src/gcs_writer.rs
@@ -91,7 +91,7 @@ impl TaskRunner<RoutedValue, RoutedValue, anyhow::Error> for GCSWriter {
 
         let bytes = match message.payload().payload {
             RoutedValuePayload::PyStreamingMessage(ref py_message) => {
-                traced_with_gil!(|py| pybytes_to_bytes(&py_message, py)).unwrap()
+                traced_with_gil!(|py| pybytes_to_bytes(py_message, py)).unwrap()
             }
             RoutedValuePayload::WatermarkMessage(..) => {
                 return Box::pin(async move { Ok(message) })
@@ -141,7 +141,7 @@ mod tests {
         traced_with_gil!(|py| {
             let arroyo_msg = make_raw_routed_msg(py, b"hello".to_vec(), "source1", vec![]);
             assert_eq!(
-                pybytes_to_bytes(&arroyo_msg.payload().payload.unwrap_payload(), py).unwrap(),
+                pybytes_to_bytes(arroyo_msg.payload().payload.unwrap_payload(), py).unwrap(),
                 b"hello".to_vec()
             );
         });

--- a/sentry_streams/src/messages.rs
+++ b/sentry_streams/src/messages.rs
@@ -129,6 +129,7 @@ pub struct PyAnyMessage {
     pub schema: Option<String>,
 }
 
+#[allow(dead_code)]
 pub fn into_pyany(py: Python<'_>, message: PyAnyMessage) -> PyResult<Py<PyAnyMessage>> {
     // Converts a PyAnyMessage instantiated outside of Python memory into a
     // Py<PyAnyMessage> that can be used in Python code.
@@ -302,7 +303,7 @@ impl RoutedValuePayload {
     /// If the payload is a `WatermarkMessage` this panics.
     pub fn unwrap_payload(&self) -> &PyStreamingMessage {
         match &self {
-            RoutedValuePayload::PyStreamingMessage(payload) => &payload,
+            RoutedValuePayload::PyStreamingMessage(payload) => payload,
             RoutedValuePayload::WatermarkMessage(..) => panic!(
                 "Invalid message payload, expected PyStreamingMessage but got WatermarkPayload."
             ),
@@ -310,10 +311,10 @@ impl RoutedValuePayload {
     }
 }
 
-impl Into<PyStreamingMessage> for Py<PyAny> {
-    fn into(self) -> PyStreamingMessage {
+impl From<Py<PyAny>> for PyStreamingMessage {
+    fn from(value: Py<PyAny>) -> Self {
         traced_with_gil!(|py| {
-            let bound = self.clone_ref(py).into_bound(py);
+            let bound = value.clone_ref(py).into_bound(py);
             if bound.is_instance_of::<PyAnyMessage>() {
                 let content = bound.downcast::<PyAnyMessage>()?;
                 Ok(PyStreamingMessage::PyAnyMessage {

--- a/sentry_streams/src/operators.rs
+++ b/sentry_streams/src/operators.rs
@@ -112,7 +112,7 @@ pub fn build(
                 route.clone(),
                 next,
                 concurrency_config,
-                &bucket,
+                bucket,
                 func_ref,
             ))
         }

--- a/sentry_streams/src/python_operator.rs
+++ b/sentry_streams/src/python_operator.rs
@@ -137,6 +137,7 @@ impl ProcessingStrategy<RoutedValue> for PythonAdapter {
     /// It understand Python some exceptions returned. Specifically:
     /// - MessageRejected is interpreted as backpressure.
     /// - InvalidMessage is interpreted as a message for DLQ.
+    ///
     /// Any other exception is unexpected and triggers a panic.
     fn submit(&mut self, message: Message<RoutedValue>) -> Result<(), SubmitError<RoutedValue>> {
         // TODO: forward watermark messages to python code instead of gating here
@@ -270,7 +271,7 @@ impl ProcessingStrategy<RoutedValue> for PythonAdapter {
                             message: transformed_message,
                         })) => {
                             self.transformed_messages.push_front(transformed_message);
-                            if deadline.map_or(false, |d| d.has_elapsed()) {
+                            if deadline.is_some_and(|d| d.has_elapsed()) {
                                 tracing::warn!("Timeout reached");
                                 break;
                             }

--- a/sentry_streams/src/routers.rs
+++ b/sentry_streams/src/routers.rs
@@ -7,6 +7,7 @@ use sentry_arroyo::processing::strategies::run_task::RunTask;
 use sentry_arroyo::processing::strategies::{InvalidMessage, ProcessingStrategy, SubmitError};
 use sentry_arroyo::types::{InnerMessage, Message};
 
+#[allow(clippy::result_large_err)]
 fn route_message(
     route: &Route,
     callable: &Py<PyAny>,
@@ -16,7 +17,7 @@ fn route_message(
         return Ok(message);
     }
     let dest_route = match message.payload().payload {
-        RoutedValuePayload::PyStreamingMessage(ref msg) => call_any_python_function(callable, &msg),
+        RoutedValuePayload::PyStreamingMessage(ref msg) => call_any_python_function(callable, msg),
         // TODO: a future PR will remove this gate on WatermarkMessage and duplicate it for each downstream route.
         RoutedValuePayload::WatermarkMessage(..) => return Ok(message),
     };

--- a/sentry_streams/src/transformer.rs
+++ b/sentry_streams/src/transformer.rs
@@ -135,90 +135,93 @@ mod tests {
         })
     }
 
-    // #[test]
-    // #[should_panic(
-    //     expected = "Got exception while processing AnyMessage, Arroyo cannot handle error on AnyMessage"
-    // )]
-    // fn test_transform_crashes_on_any_msg() {
-    //     pyo3::prepare_freethreaded_python();
+    #[ignore]
+    #[test]
+    #[should_panic(
+        expected = "Got exception while processing AnyMessage, Arroyo cannot handle error on AnyMessage"
+    )]
+    fn test_transform_crashes_on_any_msg() {
+        pyo3::prepare_freethreaded_python();
 
-    //     import_py_dep("sentry_streams.pipeline.exception", "InvalidMessageError");
+        import_py_dep("sentry_streams.pipeline.exception", "InvalidMessageError");
 
-    //     let mut transform = create_simple_transform_step(
-    //         c_str!("lambda x: (_ for _ in ()).throw(InvalidMessageError())"),
-    //         Noop {},
-    //     );
+        let mut transform = create_simple_transform_step(
+            c_str!("lambda x: (_ for _ in ()).throw(InvalidMessageError())"),
+            Noop {},
+        );
 
-    //     traced_with_gil("test_transform_crashes_on_any_msg", |py| {
-    //         let message = Message::new_any_message(
-    //             build_routed_value(
-    //                 py,
-    //                 "test_message".into_py_any(py).unwrap(),
-    //                 "source1",
-    //                 vec!["waypoint1".to_string()],
-    //             ),
-    //             BTreeMap::new(),
-    //         );
-    //         let _ = transform.submit(message);
-    //     });
-    // }
+        traced_with_gil!(|py| {
+            let message = Message::new_any_message(
+                build_routed_value(
+                    py,
+                    "test_message".into_py_any(py).unwrap(),
+                    "source1",
+                    vec!["waypoint1".to_string()],
+                ),
+                BTreeMap::new(),
+            );
+            let _ = transform.submit(message);
+        });
+    }
 
-    // #[test]
-    // #[should_panic(
-    //     expected = "Python map function raised exception that is not sentry_streams.pipeline.exception.InvalidMessageError"
-    // )]
-    // fn test_transform_crashes_on_normal_exceptions() {
-    //     pyo3::prepare_freethreaded_python();
+    #[ignore]
+    #[test]
+    #[should_panic(
+        expected = "Python map function raised exception that is not sentry_streams.pipeline.exception.InvalidMessageError"
+    )]
+    fn test_transform_crashes_on_normal_exceptions() {
+        pyo3::prepare_freethreaded_python();
 
-    //     let mut transform = create_simple_transform_step(c_str!("lambda x: {}[0]"), Noop {});
+        let mut transform = create_simple_transform_step(c_str!("lambda x: {}[0]"), Noop {});
 
-    //     traced_with_gil("test_transform_crashes_on_normal_exceptions", |py| {
-    //         let message = Message::new_any_message(
-    //             build_routed_value(
-    //                 py,
-    //                 "test_message".into_py_any(py).unwrap(),
-    //                 "source1",
-    //                 vec!["waypoint1".to_string()],
-    //             ),
-    //             BTreeMap::new(),
-    //         );
-    //         let _ = transform.submit(message);
-    //     });
-    // }
+        traced_with_gil!(|py| {
+            let message = Message::new_any_message(
+                build_routed_value(
+                    py,
+                    "test_message".into_py_any(py).unwrap(),
+                    "source1",
+                    vec!["waypoint1".to_string()],
+                ),
+                BTreeMap::new(),
+            );
+            let _ = transform.submit(message);
+        });
+    }
 
-    // #[test]
-    // fn test_transform_handles_msg_invalid_exception() {
-    //     pyo3::prepare_freethreaded_python();
+    #[ignore]
+    #[test]
+    fn test_transform_handles_msg_invalid_exception() {
+        pyo3::prepare_freethreaded_python();
 
-    //     import_py_dep("sentry_streams.pipeline.exception", "InvalidMessageError");
+        import_py_dep("sentry_streams.pipeline.exception", "InvalidMessageError");
 
-    //     let mut transform = create_simple_transform_step(
-    //         c_str!("lambda x: (_ for _ in ()).throw(InvalidMessageError())"),
-    //         Noop {},
-    //     );
+        let mut transform = create_simple_transform_step(
+            c_str!("lambda x: (_ for _ in ()).throw(InvalidMessageError())"),
+            Noop {},
+        );
 
-    //     traced_with_gil("test_transform_handles_msg_invalid_exception", |py| {
-    //         let message = Message::new_broker_message(
-    //             build_routed_value(
-    //                 py,
-    //                 "test_message".into_py_any(py).unwrap(),
-    //                 "source1",
-    //                 vec!["waypoint1".to_string()],
-    //             ),
-    //             Partition::new(Topic::new("topic"), 2),
-    //             10,
-    //             Utc::now(),
-    //         );
-    //         let SubmitError::InvalidMessage(InvalidMessage { partition, offset }) =
-    //             transform.submit(message).unwrap_err()
-    //         else {
-    //             panic!("Expected SubmitError::InvalidMessage")
-    //         };
+        traced_with_gil!(|py| {
+            let message = Message::new_broker_message(
+                build_routed_value(
+                    py,
+                    "test_message".into_py_any(py).unwrap(),
+                    "source1",
+                    vec!["waypoint1".to_string()],
+                ),
+                Partition::new(Topic::new("topic"), 2),
+                10,
+                Utc::now(),
+            );
+            let SubmitError::InvalidMessage(InvalidMessage { partition, offset }) =
+                transform.submit(message).unwrap_err()
+            else {
+                panic!("Expected SubmitError::InvalidMessage")
+            };
 
-    //         assert_eq!(partition, Partition::new(Topic::new("topic"), 2));
-    //         assert_eq!(offset, 10);
-    //     });
-    // }
+            assert_eq!(partition, Partition::new(Topic::new("topic"), 2));
+            assert_eq!(offset, 10);
+        });
+    }
 
     #[test]
     fn test_build_map() {


### PR DESCRIPTION
A few minor refactor
- Mark unused code with `#[allow(unused)]`
- Remove usage of `&` in places where the value is immediately auto-dereferenced
- Mark commented tests as #[ignore]
- Adds cargo clippy to rust CI