### PR TITLE
feat(watermarks): change watermark payload to be Py<PyAny>

### DIFF
--- a/sentry_streams/src/filter_step.rs
+++ b/sentry_streams/src/filter_step.rs
@@ -184,20 +184,17 @@ mod tests {
 
             assert_messages_match(py, expected_messages, actual_messages.deref());
 
+            let watermark = WatermarkMessage::new(BTreeMap::new());
+            let watermark_clone = watermark.clone();
             let watermark_val = RoutedValue {
                 route: Route::new(String::from("source"), vec![]),
-                payload: RoutedValuePayload::WatermarkMessage(WatermarkMessage::new(
-                    BTreeMap::new(),
-                )),
+                payload: RoutedValuePayload::WatermarkMessage(watermark),
             };
             let watermark_msg = Message::new_any_message(watermark_val, BTreeMap::new());
             let watermark_res = strategy.submit(watermark_msg);
             assert!(watermark_res.is_ok());
             let watermark_messages = submitted_watermarks_clone.lock().unwrap();
-            assert_eq!(
-                watermark_messages[0],
-                WatermarkMessage::new(BTreeMap::new())
-            );
+            assert_eq!(watermark_messages[0], watermark_clone,);
         });
     }
 }

--- a/sentry_streams/src/sinks.rs
+++ b/sentry_streams/src/sinks.rs
@@ -250,18 +250,17 @@ mod tests {
             Box::new(Noop {}),
         );
 
+        let watermark = WatermarkMessage::new(BTreeMap::new());
+        let watermark_clone = watermark.clone();
         let watermark_val = RoutedValue {
             route: Route::new(String::from("source"), vec![]),
-            payload: RoutedValuePayload::WatermarkMessage(WatermarkMessage::new(BTreeMap::new())),
+            payload: RoutedValuePayload::WatermarkMessage(watermark),
         };
         let watermark_msg = Message::new_any_message(watermark_val, BTreeMap::new());
         let watermark_res = sink.submit(watermark_msg);
         assert!(watermark_res.is_ok());
         let watermark_messages = submitted_watermarks_clone.lock().unwrap();
-        assert_eq!(
-            watermark_messages[0],
-            WatermarkMessage::new(BTreeMap::new())
-        );
+        assert_eq!(watermark_messages[0], watermark_clone,);
     }
 
     #[test]

--- a/sentry_streams/src/transformer.rs
+++ b/sentry_streams/src/transformer.rs
@@ -274,20 +274,17 @@ mod tests {
 
             assert_messages_match(py, expected_messages, actual_messages.deref());
 
+            let watermark = WatermarkMessage::new(BTreeMap::new());
+            let watermark_clone = watermark.clone();
             let watermark_val = RoutedValue {
                 route: Route::new(String::from("source"), vec![]),
-                payload: RoutedValuePayload::WatermarkMessage(WatermarkMessage::new(
-                    BTreeMap::new(),
-                )),
+                payload: RoutedValuePayload::WatermarkMessage(watermark),
             };
             let watermark_msg = Message::new_any_message(watermark_val, BTreeMap::new());
             let watermark_res = strategy.submit(watermark_msg);
             assert!(watermark_res.is_ok());
             let watermark_messages = submitted_watermarks_clone.lock().unwrap();
-            assert_eq!(
-                watermark_messages[0],
-                WatermarkMessage::new(BTreeMap::new())
-            );
+            assert_eq!(watermark_messages[0], watermark_clone,);
         });
     }
 }

--- a/sentry_streams/src/watermark.rs
+++ b/sentry_streams/src/watermark.rs
@@ -174,10 +174,8 @@ mod tests {
             // submitted WatermarkMessage contains the last seen committable
             watermark.last_sent_timestamp = 0;
             let _ = watermark.poll();
-            assert_eq!(
-                submitted_watermarks_clone.lock().unwrap()[0],
-                WatermarkMessage::new(expected_committable)
-            );
+            assert!(submitted_watermarks_clone.lock().unwrap()[0]
+                .deep_eq(&WatermarkMessage::new(expected_committable)));
         })
     }
 }


### PR DESCRIPTION
WatermarkMessages will need to be passed into python code on several occasions:
- anytime a watermark goes through a `PythonAdapter` step (such as Reduce)
- in the near future, anytime a watermark goes through an `Unfold` step (such as Broadcast, Router, FlatMap, etc) as that requires the ability to pass messages to a python function

This PR makes it so that the `committable` inside of a WatermarkMessage exists in python memory instead of being stored as a rust BTreeMap. `WatermarkMessage::new()` still takes a BTreeMap, but now takes the GIL and converts it into a python dict. `Clone` and `PartialEq` have been manually implemented so that the rest of the existing code still works.