### PR TITLE
ref(rust): Parse and handle errors when interfacing with python code in route and filter

### DIFF
--- a/sentry_streams/src/callers.rs
+++ b/sentry_streams/src/callers.rs
@@ -1,37 +1,29 @@
-use crate::messages::PyStreamingMessage;
-use crate::utils::traced_with_gil;
-use pyo3::prelude::*;
+use pyo3::{import_exception, prelude::*, types::PyTuple};
 
-/// Executes a Python callable with an Arroyo message containing Any and
-/// returns the result.
-pub fn call_python_function(
-    callable: &Py<PyAny>,
-    message: &PyStreamingMessage,
-) -> Result<PyStreamingMessage, PyErr> {
-    Ok(traced_with_gil!(|py| match message {
-        PyStreamingMessage::PyAnyMessage { ref content } => {
-            callable.call1(py, (content.clone_ref(py),))
-        }
+import_exception!(sentry_streams.pipeline.exception, InvalidMessageError);
 
-        PyStreamingMessage::RawMessage { ref content } => {
-            callable.call1(py, (content.clone_ref(py),))
-        }
-    })?
-    .into())
+pub type ApplyResult<T> = Result<T, ApplyError>;
+
+#[derive(Debug, PartialEq)]
+pub enum ApplyError {
+    InvalidMessage,
+    ApplyFailed,
 }
 
-/// Executes a Python callable with an Arroyo message containing Any and
-/// returns the result.
-pub fn call_any_python_function(
+pub fn try_apply_py<'py, N>(
+    py: Python<'py>,
     callable: &Py<PyAny>,
-    message: &PyStreamingMessage,
-) -> Result<Py<PyAny>, PyErr> {
-    traced_with_gil!(|py| match message {
-        PyStreamingMessage::PyAnyMessage { ref content } => {
-            callable.call1(py, (content.clone_ref(py),))
-        }
-        PyStreamingMessage::RawMessage { ref content } => {
-            callable.call1(py, (content.clone_ref(py),))
+    args: N,
+) -> ApplyResult<Py<PyAny>>
+where
+    N: IntoPyObject<'py, Target = PyTuple>,
+{
+    callable.call1(py, args).map_err(|py_err| {
+        py_err.print(py);
+        if py_err.is_instance(py, &py.get_type::<InvalidMessageError>()) {
+            ApplyError::InvalidMessage
+        } else {
+            ApplyError::ApplyFailed
         }
     })
 }
@@ -39,13 +31,49 @@ pub fn call_any_python_function(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::messages::PyStreamingMessage;
     use crate::messages::RoutedValuePayload;
     use crate::test_operators::build_routed_value;
+    use crate::test_operators::import_py_dep;
     use crate::test_operators::make_lambda;
+    use crate::utils::traced_with_gil;
     use pyo3::ffi::c_str;
     use pyo3::IntoPyObjectExt;
     use sentry_arroyo::types::Message;
     use std::collections::BTreeMap;
+
+    #[test]
+    fn test_apply_py_invalid_msg_err() {
+        pyo3::prepare_freethreaded_python();
+
+        import_py_dep("sentry_streams.pipeline.exception", "InvalidMessageError");
+
+        traced_with_gil!(|py| {
+            let callable = make_lambda(
+                py,
+                c_str!("lambda: (_ for _ in ()).throw(InvalidMessageError())"),
+            );
+
+            assert!(matches!(
+                try_apply_py(py, &callable, ()),
+                Err(ApplyError::InvalidMessage)
+            ));
+        });
+    }
+
+    #[test]
+    fn test_apply_py_throws_other_exception() {
+        pyo3::prepare_freethreaded_python();
+
+        traced_with_gil!(|py| {
+            let callable = make_lambda(py, c_str!("lambda x: {}[0]"));
+
+            assert!(matches!(
+                try_apply_py(py, &callable, ()),
+                Err(ApplyError::ApplyFailed)
+            ));
+        });
+    }
 
     #[test]
     fn test_call_python_function() {
@@ -68,7 +96,18 @@ mod tests {
 
             let result = match message.payload().payload {
                 RoutedValuePayload::PyStreamingMessage(ref msg) => {
-                    call_python_function(&callable, msg).unwrap()
+                    traced_with_gil!(|py| {
+                        match &msg {
+                            PyStreamingMessage::PyAnyMessage { content } => {
+                                try_apply_py(py, &callable, (content.clone_ref(py),))
+                            }
+                            PyStreamingMessage::RawMessage { content } => {
+                                try_apply_py(py, &callable, (content.clone_ref(py),))
+                            }
+                        }
+                        .unwrap()
+                        .into()
+                    })
                 }
                 RoutedValuePayload::WatermarkMessage(..) => unreachable!(),
             };

--- a/sentry_streams/src/messages.rs
+++ b/sentry_streams/src/messages.rs
@@ -311,6 +311,17 @@ impl RoutedValuePayload {
     }
 }
 
+impl From<&PyStreamingMessage> for Py<PyAny> {
+    fn from(value: &PyStreamingMessage) -> Self {
+        traced_with_gil!(|py| {
+            match &value {
+                PyStreamingMessage::PyAnyMessage { content } => content.clone_ref(py).into_any(),
+                PyStreamingMessage::RawMessage { content } => content.clone_ref(py).into_any(),
+            }
+        })
+    }
+}
+
 impl From<Py<PyAny>> for PyStreamingMessage {
     fn from(value: Py<PyAny>) -> Self {
         traced_with_gil!(|py| {

--- a/sentry_streams/src/python_operator.rs
+++ b/sentry_streams/src/python_operator.rs
@@ -2,7 +2,7 @@
 //! processing strategy that delegates the processing of messages to the
 //! python operator.
 
-use crate::messages::{PyStreamingMessage, RoutedValuePayload};
+use crate::messages::RoutedValuePayload;
 use crate::routes::{Route, RoutedValue};
 use crate::utils::traced_with_gil;
 use pyo3::types::{PyDict, PyTuple};
@@ -156,14 +156,7 @@ impl ProcessingStrategy<RoutedValue> for PythonAdapter {
                         // to python code which will use this branch.
                         watermark.clone().into_py_any(py).unwrap()
                     }
-                    RoutedValuePayload::PyStreamingMessage(ref payload) => match payload {
-                        PyStreamingMessage::PyAnyMessage { ref content } => {
-                            content.clone_ref(py).into_any()
-                        }
-                        PyStreamingMessage::RawMessage { ref content } => {
-                            content.clone_ref(py).into_any()
-                        }
-                    },
+                    RoutedValuePayload::PyStreamingMessage(ref payload) => payload.into(),
                 };
                 let py_committable = convert_committable_to_py(py, committable).unwrap();
                 match self.processing_step.call_method1(

--- a/sentry_streams/src/routers.rs
+++ b/sentry_streams/src/routers.rs
@@ -1,10 +1,10 @@
-use crate::callers::call_any_python_function;
+use crate::callers::{try_apply_py, ApplyError};
 use crate::messages::RoutedValuePayload;
 use crate::routes::{Route, RoutedValue};
 use crate::utils::traced_with_gil;
 use pyo3::prelude::*;
 use sentry_arroyo::processing::strategies::run_task::RunTask;
-use sentry_arroyo::processing::strategies::{InvalidMessage, ProcessingStrategy, SubmitError};
+use sentry_arroyo::processing::strategies::{ProcessingStrategy, SubmitError};
 use sentry_arroyo::types::{InnerMessage, Message};
 
 #[allow(clippy::result_large_err)]
@@ -16,25 +16,30 @@ fn route_message(
     if message.payload().route != *route {
         return Ok(message);
     }
-    let dest_route = match message.payload().payload {
-        RoutedValuePayload::PyStreamingMessage(ref msg) => call_any_python_function(callable, msg),
+
+    let RoutedValuePayload::PyStreamingMessage(ref py_streaming_msg) = message.payload().payload
+    else {
         // TODO: a future PR will remove this gate on WatermarkMessage and duplicate it for each downstream route.
-        RoutedValuePayload::WatermarkMessage(..) => return Ok(message),
+        return Ok(message);
     };
-    match dest_route {
-        Ok(dest_route) => {
-            let new_waypoint = traced_with_gil!(|py| { dest_route.extract::<String>(py).unwrap() });
+
+    let res = traced_with_gil!(|py| {
+        try_apply_py(py, callable, (Into::<Py<PyAny>>::into(py_streaming_msg),)).and_then(
+            |py_res| {
+                py_res
+                    .extract::<String>(py)
+                    .map_err(|_| ApplyError::ApplyFailed)
+            },
+        )
+    });
+
+    match (res, &message.inner_message) {
+        (Ok(new_waypoint), _) => {
             message.try_map(|payload| Ok(payload.add_waypoint(new_waypoint.clone())))
-        }
-        Err(_) => match message.inner_message {
-            InnerMessage::BrokerMessage(inner) => {
-                Err(SubmitError::InvalidMessage(InvalidMessage {
-                    partition: inner.partition,
-                    offset: inner.offset,
-                }))
-            }
-            InnerMessage::AnyMessage(inner) => panic!("Unexpected message type: {:?}", inner),
         },
+        (Err(ApplyError::ApplyFailed), _) => panic!("Python route function raised exception that is not sentry_streams.pipeline.exception.InvalidMessageError"),
+        (Err(ApplyError::InvalidMessage), InnerMessage::AnyMessage(..)) => panic!("Got exception while processing AnyMessage, Arroyo cannot handle error on AnyMessage"),
+        (Err(ApplyError::InvalidMessage),  InnerMessage::BrokerMessage(broker_message)) => Err(SubmitError::InvalidMessage(broker_message.into()))
     }
 }
 
@@ -58,11 +63,120 @@ pub fn build_router(
 mod tests {
     use super::*;
     use crate::test_operators::build_routed_value;
+    use crate::test_operators::import_py_dep;
     use crate::test_operators::make_lambda;
     use crate::utils::traced_with_gil;
+    use chrono::Utc;
     use pyo3::ffi::c_str;
     use pyo3::IntoPyObjectExt;
+    use sentry_arroyo::processing::strategies::noop::Noop;
+    use sentry_arroyo::processing::strategies::InvalidMessage;
+    use sentry_arroyo::types::Partition;
+    use sentry_arroyo::types::Topic;
     use std::collections::BTreeMap;
+    use std::ffi::CStr;
+
+    fn create_simple_router<T>(
+        lambda_body: &CStr,
+        next_step: T,
+    ) -> Box<dyn ProcessingStrategy<RoutedValue>>
+    where
+        T: ProcessingStrategy<RoutedValue> + 'static,
+    {
+        traced_with_gil!(|py| {
+            py.run(lambda_body, None, None).expect("Unable to import");
+            let callable = make_lambda(py, lambda_body);
+
+            build_router(
+                &Route::new("source1".to_string(), vec!["waypoint1".to_string()]),
+                callable,
+                Box::new(next_step),
+            )
+        })
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Got exception while processing AnyMessage, Arroyo cannot handle error on AnyMessage"
+    )]
+    fn test_router_crashes_on_any_msg() {
+        pyo3::prepare_freethreaded_python();
+
+        import_py_dep("sentry_streams.pipeline.exception", "InvalidMessageError");
+
+        let mut router = create_simple_router(
+            c_str!("lambda x: (_ for _ in ()).throw(InvalidMessageError())"),
+            Noop {},
+        );
+
+        traced_with_gil!(|py| {
+            let message = Message::new_any_message(
+                build_routed_value(
+                    py,
+                    "test_message".into_py_any(py).unwrap(),
+                    "source1",
+                    vec!["waypoint1".to_string()],
+                ),
+                BTreeMap::new(),
+            );
+            let _ = router.submit(message);
+        });
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Python route function raised exception that is not sentry_streams.pipeline.exception.InvalidMessageError"
+    )]
+    fn test_router_crashes_on_normal_exceptions() {
+        pyo3::prepare_freethreaded_python();
+
+        let mut router = create_simple_router(c_str!("lambda x: {}[0]"), Noop {});
+
+        traced_with_gil!(|py| {
+            let message = Message::new_any_message(
+                build_routed_value(
+                    py,
+                    "test_message".into_py_any(py).unwrap(),
+                    "source1",
+                    vec!["waypoint1".to_string()],
+                ),
+                BTreeMap::new(),
+            );
+            let _ = router.submit(message);
+        });
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Python route function raised exception that is not sentry_streams.pipeline.exception.InvalidMessageError"
+    )]
+    fn test_router_handles_invalid_msg_exception() {
+        pyo3::prepare_freethreaded_python();
+
+        let mut router = create_simple_router(c_str!("lambda x: {}[0]"), Noop {});
+
+        traced_with_gil!(|py| {
+            let message = Message::new_broker_message(
+                build_routed_value(
+                    py,
+                    "test_message".into_py_any(py).unwrap(),
+                    "source1",
+                    vec!["waypoint1".to_string()],
+                ),
+                Partition::new(Topic::new("topic"), 2),
+                10,
+                Utc::now(),
+            );
+            let SubmitError::InvalidMessage(InvalidMessage { partition, offset }) =
+                router.submit(message).unwrap_err()
+            else {
+                panic!("Expected SubmitError::InvalidMessage")
+            };
+
+            assert_eq!(partition, Partition::new(Topic::new("topic"), 2));
+            assert_eq!(offset, 10);
+        });
+    }
 
     #[test]
     fn test_route_msg() {

--- a/sentry_streams/src/test_operators.rs
+++ b/sentry_streams/src/test_operators.rs
@@ -12,6 +12,23 @@ use std::collections::BTreeMap;
 use std::ffi::CStr;
 
 #[cfg(test)]
+pub fn import_py_dep(module: &str, attr: &str) {
+    use std::ffi::CString;
+
+    use crate::utils::traced_with_gil;
+
+    let stmt = format!("from {} import {}", module, attr);
+    traced_with_gil!(|py| {
+        py.run(
+            &CString::new(stmt).expect("Unable to convert import statement into Cstr"),
+            None,
+            None,
+        )
+        .expect("Unable to import");
+    });
+}
+
+#[cfg(test)]
 pub fn make_lambda(py: Python<'_>, py_code: &CStr) -> Py<PyAny> {
     py.eval(py_code, None, None)
         .unwrap()

--- a/sentry_streams/src/transformer.rs
+++ b/sentry_streams/src/transformer.rs
@@ -1,15 +1,12 @@
-use crate::callers::call_python_function;
+use crate::callers::{try_apply_py, ApplyError};
 use crate::filter_step::Filter;
 use crate::messages::RoutedValuePayload;
 use crate::routes::{Route, RoutedValue};
 use crate::utils::traced_with_gil;
-use pyo3::import_exception;
 use pyo3::prelude::*;
 use sentry_arroyo::processing::strategies::run_task::RunTask;
 use sentry_arroyo::processing::strategies::{ProcessingStrategy, SubmitError};
-use sentry_arroyo::types::Message;
-
-import_exception!(sentry_streams.pipeline.exception, InvalidMessageError);
+use sentry_arroyo::types::{InnerMessage, Message};
 
 /// Creates an Arroyo transformer strategy that uses a Python callable to
 /// transform messages. The callable is expected to take a Message<RoutedValue>
@@ -36,31 +33,19 @@ pub fn build_map(
 
         let route = message.payload().route.clone();
 
-        let transformed = call_python_function(&callable, py_streaming_msg).map_err(|py_err| {
-            // TODO: Ideally this should be built into an abstraction like
-            // call_python_function, where someone can call it and it handles
-            // things like printing the stacktrace and returns a custom variant
-            // if the exception is a InvalidMessageError
-            if !traced_with_gil!(|py| {
-                py_err.print(py);
-                py_err.is_instance(py, &py.get_type::<InvalidMessageError>())
-            }) {
-                 panic!("Python map function raised exception that is not sentry_streams.pipeline.exception.InvalidMessageError")
-            }
+        let res = traced_with_gil!(|py| {
+            try_apply_py(py, &callable, (Into::<Py<PyAny>>::into(py_streaming_msg),))
+        });
 
-            let sentry_arroyo::types::InnerMessage::BrokerMessage(ref broker_message) =
-                message.inner_message
-            else {
-                panic!("Got exception while processing AnyMessage, Arroyo cannot handle error on AnyMessage")
-            };
-
-            SubmitError::InvalidMessage(broker_message.into())
-        })?;
-
-        Ok(message.replace(RoutedValue {
-            route,
-            payload: RoutedValuePayload::PyStreamingMessage(transformed),
-        }))
+        match (res, &message.inner_message) {
+            (Ok(transformed), _) => Ok(message.replace(RoutedValue {
+                route,
+                payload: RoutedValuePayload::PyStreamingMessage(transformed.into()),
+            })),
+            (Err(ApplyError::ApplyFailed), _) => panic!("Python map function raised exception that is not sentry_streams.pipeline.exception.InvalidMessageError"),
+            (Err(ApplyError::InvalidMessage), InnerMessage::AnyMessage(..)) => panic!("Got exception while processing AnyMessage, Arroyo cannot handle error on AnyMessage"),
+            (Err(ApplyError::InvalidMessage),  InnerMessage::BrokerMessage(broker_message)) => Err(SubmitError::InvalidMessage(broker_message.into()))
+        }
     };
     Box::new(RunTask::new(mapper, next))
 }
@@ -88,6 +73,7 @@ mod tests {
     use crate::messages::WatermarkMessage;
     use crate::routes::Route;
     use crate::test_operators::build_routed_value;
+    use crate::test_operators::import_py_dep;
     use crate::test_operators::make_lambda;
     use crate::utils::traced_with_gil;
     use chrono::Utc;
@@ -100,21 +86,8 @@ mod tests {
     use sentry_arroyo::types::Topic;
     use std::collections::BTreeMap;
     use std::ffi::CStr;
-    use std::ffi::CString;
     use std::ops::Deref;
     use std::sync::{Arc, Mutex};
-
-    fn import_py_dep(module: &str, attr: &str) {
-        let stmt = format!("from {} import {}", module, attr);
-        traced_with_gil!(|py| {
-            py.run(
-                &CString::new(stmt).expect("Unable to convert import statement into Cstr"),
-                None,
-                None,
-            )
-            .expect("Unable to import");
-        });
-    }
 
     fn create_simple_transform_step<T>(
         lambda_body: &CStr,
@@ -135,7 +108,6 @@ mod tests {
         })
     }
 
-    #[ignore]
     #[test]
     #[should_panic(
         expected = "Got exception while processing AnyMessage, Arroyo cannot handle error on AnyMessage"
@@ -164,7 +136,6 @@ mod tests {
         });
     }
 
-    #[ignore]
     #[test]
     #[should_panic(
         expected = "Python map function raised exception that is not sentry_streams.pipeline.exception.InvalidMessageError"
@@ -188,9 +159,8 @@ mod tests {
         });
     }
 
-    #[ignore]
     #[test]
-    fn test_transform_handles_msg_invalid_exception() {
+    fn test_transform_handles_invalid_msg_exception() {
         pyo3::prepare_freethreaded_python();
 
         import_py_dep("sentry_streams.pipeline.exception", "InvalidMessageError");


### PR DESCRIPTION
- Unify rust → python facilities in `transform`, `route` and `filter` with `try_apply_py`. When calling into python with `try_apply_py` the return value will be `Result<T, ApplyError>`, where `ApplyError` can be either `InvalidMessage`, which is meant to signal to the event loop to not retry the message, or `ApplyFailed`, which indicates some ordinary errors. `try_apply_py` also handles logging python stack traces in event of an error.
- Add conversion for `ApplyError::InvalidMessage` → Arroyo runtime's `MessageRejected`
- Implements `Into` traits for `PyStreamingMessage` → `Py<PyAny>`, since we're doing the `match` + `clone_ref` over and over again.