### PR TITLE
temp(rust): allow certain tests to be disabled with cfg

### DIFF
--- a/sentry_streams/Cargo.toml
+++ b/sentry_streams/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 
 [dependencies]
-pyo3 = { version = "0.24.0"}
+pyo3 = { version = "0.24.0" }
 serde = { version = "1.0", features = ["derive"] }
 sentry_arroyo = "2.19.5"
 chrono = "0.4.40"
@@ -23,7 +23,9 @@ name = "rust_streams"
 crate-type = ["cdylib"]
 
 [features]
+default = ["enable_py_import_tests"]
 extension-module = ["pyo3/extension-module"]
+enable_py_import_tests = []
 
 [dev-dependencies]
 parking_lot = "0.12.1"

--- a/sentry_streams/src/callers.rs
+++ b/sentry_streams/src/callers.rs
@@ -43,7 +43,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     #[test]
-    #[ignore]
+    #[cfg(feature = "enable_py_import_tests")]
     fn test_apply_py_invalid_msg_err() {
         pyo3::prepare_freethreaded_python();
 
@@ -63,7 +63,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[cfg(feature = "enable_py_import_tests")]
     fn test_apply_py_throws_other_exception() {
         pyo3::prepare_freethreaded_python();
 

--- a/sentry_streams/src/filter_step.rs
+++ b/sentry_streams/src/filter_step.rs
@@ -125,7 +125,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[cfg(feature = "enable_py_import_tests")]
     #[should_panic(
         expected = "Got exception while processing AnyMessage, Arroyo cannot handle error on AnyMessage"
     )]
@@ -154,7 +154,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[cfg(feature = "enable_py_import_tests")]
     #[should_panic(
         expected = "Python filter function raised exception that is not sentry_streams.pipeline.exception.InvalidMessageError"
     )]
@@ -178,7 +178,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[cfg(feature = "enable_py_import_tests")]
     fn test_filter_handles_invalid_msg_exception() {
         pyo3::prepare_freethreaded_python();
 

--- a/sentry_streams/src/routers.rs
+++ b/sentry_streams/src/routers.rs
@@ -96,7 +96,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[cfg(feature = "enable_py_import_tests")]
     #[should_panic(
         expected = "Got exception while processing AnyMessage, Arroyo cannot handle error on AnyMessage"
     )]
@@ -125,7 +125,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[cfg(feature = "enable_py_import_tests")]
     #[should_panic(
         expected = "Python route function raised exception that is not sentry_streams.pipeline.exception.InvalidMessageError"
     )]
@@ -149,7 +149,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[cfg(feature = "enable_py_import_tests")]
     #[should_panic(
         expected = "Python route function raised exception that is not sentry_streams.pipeline.exception.InvalidMessageError"
     )]

--- a/sentry_streams/src/transformer.rs
+++ b/sentry_streams/src/transformer.rs
@@ -109,7 +109,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[cfg(feature = "enable_py_import_tests")]
     #[should_panic(
         expected = "Got exception while processing AnyMessage, Arroyo cannot handle error on AnyMessage"
     )]
@@ -138,7 +138,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[cfg(feature = "enable_py_import_tests")]
     #[should_panic(
         expected = "Python map function raised exception that is not sentry_streams.pipeline.exception.InvalidMessageError"
     )]
@@ -162,7 +162,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[cfg(feature = "enable_py_import_tests")]
     fn test_transform_handles_invalid_msg_exception() {
         pyo3::prepare_freethreaded_python();
 


### PR DESCRIPTION
Since some tests are broken in certain environment. Add a cfg to disable those test.
`cargo test`: will run all tests
`cargo test --no-default-features`: will skip tests that may fail if python environment is broken.