### PR TITLE
fix: replace freedthreaded_python with initialize_python everywhere

### DIFF
--- a/sentry_streams/src/broadcaster.rs
+++ b/sentry_streams/src/broadcaster.rs
@@ -173,7 +173,7 @@ mod tests {
 
     #[test]
     fn test_message_rejected() {
-        pyo3::prepare_freethreaded_python();
+        crate::testutils::initialize_python();
         traced_with_gil!(|py| {
             let submitted_messages = Arc::new(Mutex::new(Vec::new()));
             let submitted_messages_clone = submitted_messages.clone();

--- a/sentry_streams/src/callers.rs
+++ b/sentry_streams/src/callers.rs
@@ -44,7 +44,7 @@ mod tests {
 
     #[test]
     fn test_apply_py_invalid_msg_err() {
-        pyo3::prepare_freethreaded_python();
+        crate::testutils::initialize_python();
 
         import_py_dep("sentry_streams.pipeline.exception", "InvalidMessageError");
 
@@ -63,7 +63,7 @@ mod tests {
 
     #[test]
     fn test_apply_py_throws_other_exception() {
-        pyo3::prepare_freethreaded_python();
+        crate::testutils::initialize_python();
 
         traced_with_gil!(|py| {
             let callable = make_lambda(py, c_str!("lambda x: {}[0]"));

--- a/sentry_streams/src/committable.rs
+++ b/sentry_streams/src/committable.rs
@@ -63,7 +63,7 @@ mod test {
 
     #[test]
     fn test_convert_committable_to_py_and_back() {
-        pyo3::prepare_freethreaded_python();
+        crate::testutils::initialize_python();
         traced_with_gil!(|py| {
             // Prepare a committable with two partitions
             let committable = make_committable(2, 0);

--- a/sentry_streams/src/filter_step.rs
+++ b/sentry_streams/src/filter_step.rs
@@ -129,7 +129,7 @@ mod tests {
         expected = "Got exception while processing AnyMessage, Arroyo cannot handle error on AnyMessage"
     )]
     fn test_filter_crashes_on_any_msg() {
-        pyo3::prepare_freethreaded_python();
+        crate::testutils::initialize_python();
 
         import_py_dep("sentry_streams.pipeline.exception", "InvalidMessageError");
 
@@ -157,7 +157,7 @@ mod tests {
         expected = "Python filter function raised exception that is not sentry_streams.pipeline.exception.InvalidMessageError"
     )]
     fn test_filter_crashes_on_normal_exceptions() {
-        pyo3::prepare_freethreaded_python();
+        crate::testutils::initialize_python();
 
         let mut filter = create_simple_filter(c_str!("lambda x: {}[0]"), Noop {});
 
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn test_filter_handles_invalid_msg_exception() {
-        pyo3::prepare_freethreaded_python();
+        crate::testutils::initialize_python();
 
         import_py_dep("sentry_streams.pipeline.exception", "InvalidMessageError");
 

--- a/sentry_streams/src/messages.rs
+++ b/sentry_streams/src/messages.rs
@@ -626,7 +626,7 @@ mod tests {
 
     #[test]
     fn test_pywatermark_lifecycle() {
-        pyo3::prepare_freethreaded_python();
+        crate::testutils::initialize_python();
         traced_with_gil!(|py| {
             // Prepare test data
             let committable = PyDict::new(py);

--- a/sentry_streams/src/python_operator.rs
+++ b/sentry_streams/src/python_operator.rs
@@ -392,7 +392,7 @@ class RustOperatorDelegateFactory:
 
     #[test]
     fn test_submit_watermark() {
-        pyo3::prepare_freethreaded_python();
+        crate::testutils::initialize_python();
         traced_with_gil!(|py| {
             let instance = build_operator(py);
             let mut operator = PythonAdapter::new(

--- a/sentry_streams/src/routers.rs
+++ b/sentry_streams/src/routers.rs
@@ -100,7 +100,7 @@ mod tests {
         expected = "Got exception while processing AnyMessage, Arroyo cannot handle error on AnyMessage"
     )]
     fn test_router_crashes_on_any_msg() {
-        pyo3::prepare_freethreaded_python();
+        crate::testutils::initialize_python();
 
         import_py_dep("sentry_streams.pipeline.exception", "InvalidMessageError");
 
@@ -128,7 +128,7 @@ mod tests {
         expected = "Python route function raised exception that is not sentry_streams.pipeline.exception.InvalidMessageError"
     )]
     fn test_router_crashes_on_normal_exceptions() {
-        pyo3::prepare_freethreaded_python();
+        crate::testutils::initialize_python();
 
         let mut router = create_simple_router(c_str!("lambda x: {}[0]"), Noop {});
 
@@ -151,7 +151,7 @@ mod tests {
         expected = "Python route function raised exception that is not sentry_streams.pipeline.exception.InvalidMessageError"
     )]
     fn test_router_handles_invalid_msg_exception() {
-        pyo3::prepare_freethreaded_python();
+        crate::testutils::initialize_python();
 
         let mut router = create_simple_router(c_str!("lambda x: {}[0]"), Noop {});
 


### PR DESCRIPTION
After #158 we should only be using `initialize_python()` for all tests as that uses the correct python for tests