### PR TITLE
ignore .rst in merge conflict pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
       - id: check-case-conflict
       - id: check-merge-conflict
+        files: ^(?!.*\.rst).*
       - id: check-symlinks
       - id: check-xml
       - id: check-yaml


### PR DESCRIPTION
Our `.rst` files use `===========` as headers, so if we ever get a merge conflict while editing one the pre-commit check won't ever resolve. This ignores .rst files in the check.