### PR TITLE
feat(tests): Add an integration test for an example pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,19 +11,40 @@ jobs:
     name: "Run tests"
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v3
-        - uses: actions/setup-python@v5
-          with:
-            python-version-file: sentry_streams/.python-version
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: sentry_streams/.python-version
 
-        - name: Make environment
-          run: |
-            make install-dev
+      - name: Make environment
+        run: |
+          make install-dev
 
-        - name: Run streams test
-          run: make tests-streams
+      - name: Run streams test
+        run: make tests-streams
 
-        - name: Run flink test
-          run: make tests-flink
-          env:
-            FLINK_LIBS: ./flink_libs
+      - name: Run flink test
+        run: make tests-flink
+        env:
+          FLINK_LIBS: ./flink_libs
+
+  integration-tests:
+    name: "Run integration tests"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: sentry_streams/.python-version
+
+      - name: Make environment
+        run: |
+          make install-dev
+
+      - name: Start services
+        id: setup
+        run: |
+          devservices up
+
+      - name: Run integration tests
+        run: make tests-integration

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,20 +32,23 @@ repos:
       - id: flake8
         language_version: python3.11
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.14.1'
+    rev: "v1.14.1"
     hooks:
-    -   id: mypy
+      - id: mypy
         args: [--config-file, sentry_streams/mypy.ini, --strict]
-        additional_dependencies: [
-          pytest==7.1.2,
-          types-requests,
-          responses,
-          "sentry-arroyo>=2.18.2",
-          types-pyYAML,
-          types-jsonschema,
-          "sentry-kafka-schemas>=1.2.0",
-          "polars==1.30.0",
-        ]
+        additional_dependencies:
+          [
+            pytest==7.1.2,
+            types-requests,
+            responses,
+            click,
+            types-confluent-kafka,
+            "sentry-arroyo>=2.18.2",
+            types-pyYAML,
+            types-jsonschema,
+            "sentry-kafka-schemas>=1.2.0",
+            "polars==1.30.0",
+          ]
         files: ^sentry_streams/.+
   - repo: https://github.com/pycqa/isort
     rev: 6.0.0

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ tests-streams:
 	./sentry_streams/.venv/bin/pytest -vv sentry_streams/tests
 .PHONY: tests-streams
 
+tests-integration:
+	./sentry_streams/.venv/bin/pytest -vv sentry_streams/integration_tests
+.PHONY: tests-integration
+
 test-rust-streams:
 	. sentry_streams/.venv/bin/activate && . scripts/rust-envvars && cd ./sentry_streams/ && cargo test
 .PHONY: tests-rust-streams

--- a/sentry_streams/docs/source/intro.rst
+++ b/sentry_streams/docs/source/intro.rst
@@ -104,6 +104,7 @@ Note that if these topics don't exist, they will need to be created. With docker
     -n Batch \
     --config sentry_streams/deployment_config/<YOUR CONFIG FILE>.yaml \
     --adapter rust-arroyo \
+    --segment-id 0 \
     <YOUR PIPELINE FILE>
 
 for the above code example, use `sentry_streams/sentry_streams/deployment_config/simple_map_filter.yaml` for the deployment config file (assuming you have two local Kafka topics for source and sink)

--- a/sentry_streams/integration_tests/test_example_pipelines.py
+++ b/sentry_streams/integration_tests/test_example_pipelines.py
@@ -1,0 +1,230 @@
+import json
+import os
+import signal
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from confluent_kafka import Consumer, KafkaException, Producer
+
+TEST_PRODUCER_CONFIG = {
+    "bootstrap.servers": "127.0.0.1:9092",
+    "broker.address.family": "v4",
+}
+TEST_CONSUMER_CONFIG = {
+    "bootstrap.servers": "127.0.0.1:9092",
+    "group.id": "pipeline-test-consumer",
+    "auto.offset.reset": "earliest",
+}
+
+
+@dataclass
+class PipelineRun:
+    name: str
+    config_file: str
+    application_file: str
+    source_topic: str
+    sink_topics: list[str]
+    input_messages: list[str]
+    num_expected_messages: dict[str, int]
+
+
+def create_ingest_message(**kwargs: Any) -> str:
+    message = {
+        "org_id": 420,
+        "project_id": 420,
+        "name": "s:sessions/user@none",
+        "tags": {
+            "sdk": "raven-node/2.6.3",
+            "environment": "production",
+            "release": "sentry-test@1.0.0",
+        },
+        "timestamp": 1846062325,
+        "type": "c",
+        "retention_days": 90,
+        "value": [1617781333],
+    }
+    message.update(kwargs)
+    return json.dumps(message)
+
+
+def create_topic(topic_name: str, num_partitions: int) -> None:
+    print(f"Creating topic: {topic_name}, with {num_partitions} partitions")
+    create_topic_cmd = [
+        "docker",
+        "exec",
+        "kafka-kafka-1",
+        "kafka-topics",
+        "--bootstrap-server",
+        "localhost:9092",
+        "--create",
+        "--topic",
+        topic_name,
+        "--partitions",
+        str(num_partitions),
+    ]
+    res = subprocess.run(create_topic_cmd, capture_output=True, text=True)
+    if res.returncode != 0:
+        if "already exists" in res.stderr:
+            return
+
+        print(f"Got return code: {res.returncode}, when creating topic")
+        print(f"Stdout: {res.stdout}")
+        print(f"Stderr: {res.stderr}")
+        raise Exception(f"Failed to create topic: {topic_name}")
+
+
+def run_pipeline_cmd(test: PipelineRun) -> subprocess.Popen[str]:
+    """
+    Run the pipeline using the command line interface.
+    """
+    process = subprocess.Popen[str](
+        [
+            "python",
+            "-m",
+            "sentry_streams.runner",
+            "--adapter",
+            "rust_arroyo",
+            "--config",
+            test.config_file,
+            "--segment-id",
+            "0",
+            test.application_file,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return process
+
+
+def send_messages_to_topic(topic_name: str, messages: list[str]) -> None:
+    """
+    Send messages to kafka topic.
+    """
+    try:
+        producer = Producer(TEST_PRODUCER_CONFIG)
+
+        for message in messages:
+            producer.produce(topic_name, message)
+
+        producer.flush()
+        print(f"Sent {len(messages)} messages to kafka topic {topic_name}")
+    except Exception as e:
+        raise Exception(f"Failed to send messages to kafka: {e}")
+
+
+def get_topic_size(topic_name: str) -> int:
+    """
+    Creates a consumer and polls the topic starting at the earliest offset
+    attempts are exhausted.
+    """
+    attempts = 30
+    size = 0
+    consumer = Consumer(TEST_CONSUMER_CONFIG)
+    consumer.subscribe([topic_name])
+    while attempts > 0:
+        event = consumer.poll(1.0)
+        if event is None:
+            attempts -= 1
+            continue
+        if event.error():
+            raise KafkaException(event.error())
+        else:
+            size += 1
+
+    return size
+
+
+def run_example_test(test: PipelineRun) -> None:
+    print(f"{test.name}: Creating topics")
+    create_topic(test.source_topic, 1)
+    for sink_topic in test.sink_topics:
+        create_topic(sink_topic, 1)
+
+    print(f"{test.name}: Running pipeline")
+    process = run_pipeline_cmd(test)
+
+    print(f"{test.name}: Sending messages")
+    send_messages_to_topic(test.source_topic, test.input_messages)
+
+    print(f"{test.name}: Waiting for messages")
+    start_time = time.time()
+    while time.time() - start_time < 30:
+        if process.poll() is not None:  # Runner shouldn't stop
+            stdout, stderr = process.communicate()
+            print(f"Pipeline process exited with code {process.returncode}")
+            print(f"Stdout: {stdout}")
+            print(f"Stderr: {stderr}")
+            raise Exception(f"Pipeline process exited with code {process.returncode}")
+
+        received = {}
+        for sink_topic in test.sink_topics:
+            size = get_topic_size(sink_topic)
+            received[sink_topic] = (size, size == test.num_expected_messages[sink_topic])
+            print(f"{test.name}: Received {received[sink_topic]} messages from {sink_topic}")
+
+        if all(v[1] for v in received.values()):
+            break
+
+        time.sleep(1)
+
+    print(f"{test.name}: Waiting for process to exit")
+    process.send_signal(signal.SIGKILL)
+    process.wait()
+    stdout, stderr = process.communicate()
+    print(f"Stdout: {stdout}")
+    print(f"Stderr: {stderr}")
+
+    for sink_topic, (size, expected) in received.items():
+        assert (
+            expected
+        ), f"Expected {test.num_expected_messages[sink_topic]} messages on {sink_topic}, got {size}"
+
+
+example_tests = [
+    pytest.param(
+        "simple_map_filter",
+        "ingest-metrics",
+        ["transformed-events"],
+        [create_ingest_message(type="c")],
+        {"transformed-events": 1},
+        id="simple_map_filter",
+    )
+]
+
+
+@pytest.mark.parametrize(
+    "name, source_topic, sink_topics, input_messages, expected_messages", example_tests
+)
+def test_examples(
+    name: str,
+    source_topic: str,
+    sink_topics: list[str],
+    input_messages: list[str],
+    expected_messages: dict[str, int],
+) -> None:
+    test = PipelineRun(
+        name=name,
+        config_file=os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "sentry_streams",
+            "deployment_config",
+            f"{name}.yaml",
+        ),
+        application_file=os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "sentry_streams",
+            "examples",
+            f"{name}.py",
+        ),
+        source_topic=source_topic,
+        sink_topics=sink_topics,
+        input_messages=input_messages,
+        num_expected_messages=expected_messages,
+    )
+    run_example_test(test)

--- a/sentry_streams/pyproject.toml
+++ b/sentry_streams/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "jsonschema>=4.23.0",
     "sentry-kafka-schemas>=1.2.0",
     "polars",
+    "click>=8.2.1",
+    "devservices==1.1.5",
+    "types-confluent-kafka>=1.3.4",
 ]
 
 [dependency-groups]

--- a/sentry_streams/sentry_streams/examples/simple_map_filter.py
+++ b/sentry_streams/sentry_streams/examples/simple_map_filter.py
@@ -1,9 +1,6 @@
-from datetime import datetime
-
 from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 
-from sentry_streams.examples.transform_metrics import transform_msg
-from sentry_streams.pipeline.message import Message
+from sentry_streams.examples.transform_metrics import filter_events, transform_msg
 from sentry_streams.pipeline.pipeline import (
     Filter,
     Map,
@@ -12,18 +9,6 @@ from sentry_streams.pipeline.pipeline import (
     StreamSink,
     streaming_source,
 )
-
-
-def filter_events(msg: Message[IngestMetric]) -> bool:
-    return bool(msg.payload["type"] == "c")
-
-
-def generate_files() -> str:
-    now = datetime.now()
-    cur_time = now.strftime("%H:%M:%S")
-
-    return f"file_{cur_time}.txt"
-
 
 pipeline = streaming_source(name="myinput", stream_name="ingest-metrics")
 

--- a/sentry_streams/sentry_streams/examples/transform_metrics.py
+++ b/sentry_streams/sentry_streams/examples/transform_metrics.py
@@ -13,3 +13,8 @@ def transform_msg(msg: Message[IngestMetric]) -> Mapping[str, Any]:
     num += 1
     print(f"Current PID: {os.getpid()} {num}")
     return {**msg.payload, "transformed": True}
+
+
+def filter_events(msg: Message[IngestMetric]) -> bool:
+    print(f"Filtering event: {msg.payload}")
+    return bool(msg.payload["type"] == "c")

--- a/sentry_streams/sentry_streams/runner.py
+++ b/sentry_streams/sentry_streams/runner.py
@@ -1,11 +1,10 @@
-import argparse
 import importlib
 import json
 import logging
-import os
 import signal
 from typing import Any, Optional, cast
 
+import click
 import jsonschema
 import yaml
 
@@ -54,67 +53,26 @@ def iterate_edges(p_graph: Pipeline, translator: RuntimeTranslator[StreamT, Stre
                     step_streams[branch_name] = next_step_stream[branch_name]
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Runs a Flink application.")
-    parser.add_argument(
-        "--name",
-        "-n",
-        type=str,
-        default="Flink Job",
-        help="The name of the Flink Job",
-    )
-    parser.add_argument(
-        "--log-level",
-        "-l",
-        type=str,
-        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-        default="INFO",
-        help="Set the logging level",
-    )
-    parser.add_argument(
-        "--adapter",
-        "-a",
-        # remove choices list in the future when custom local adapters are widely used
-        # for now just arroyo and rust_arroyo will be commonly used
-        choices=["arroyo", "rust_arroyo"],
-        # TODO: Remove the support for dynamically load the class.
-        # Add a runner CLI in the flink package instead that instantiates
-        # the Flink adapter.
-        help=(
-            "The stream adapter to instantiate. It can be one of the allowed values from "
-            "the load_adapter function"
-        ),
-    )
-    parser.add_argument(
-        "--config",
-        type=str,
-        help=(
-            "The deployment config file path. Each config file currently corresponds to a specific pipeline."
-        ),
-    )
-    parser.add_argument(
-        "application",
-        type=str,
-        help=(
-            "The Sentry Stream application file. This has to be relative "
-            "to the path mounted in the job manager as the /apps directory."
-        ),
-    )
-
+def runner(
+    name: str,
+    log_level: str,
+    adapter: str,
+    config: str,
+    segment_id: Optional[str],
+    application: str,
+) -> None:
     pipeline_globals: dict[str, Any] = {}
 
-    args = parser.parse_args()
-
     logging.basicConfig(
-        level=args.log_level,
+        level=log_level,
         format="%(asctime)s - %(levelname)s - %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 
-    with open(args.application) as f:
+    with open(application) as f:
         exec(f.read(), pipeline_globals)
 
-    with open(args.config, "r") as config_file:
+    with open(config, "r") as config_file:
         environment_config = yaml.safe_load(config_file)
 
     config_template = importlib.resources.files("sentry_streams") / "config.json"
@@ -126,18 +84,9 @@ def main() -> None:
         except Exception:
             raise
 
+    assigned_segment_id = int(segment_id) if segment_id else None
     pipeline: Pipeline = pipeline_globals["pipeline"]
-
-    # If set, SEGMENT_ID must correspond to the 0-indexed position in the segments array in config
-    segment_var = os.environ.get("SEGMENT_ID")
-    segment_id: Optional[int]
-    if segment_var:
-        assert segment_var is not None
-        segment_id = int(segment_var)
-    else:
-        segment_id = None
-
-    runtime: Any = load_adapter(args.adapter, environment_config, segment_id)
+    runtime: Any = load_adapter(adapter, environment_config, assigned_segment_id)
     translator = RuntimeTranslator(runtime)
 
     iterate_edges(pipeline, translator)
@@ -150,6 +99,64 @@ def main() -> None:
     signal.signal(signal.SIGTERM, signal_handler)
 
     runtime.run()
+
+
+@click.command()
+@click.option(
+    "--name",
+    "-n",
+    default="Sentry Streams",
+    show_default=True,
+    help="The name of the Sentry Streams application",
+)
+@click.option(
+    "--log-level",
+    "-l",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
+    default="INFO",
+    show_default=True,
+    help="Set the logging level",
+)
+@click.option(
+    "--adapter",
+    "-a",
+    # remove choices list in the future when custom local adapters are widely used
+    # for now just arroyo and rust_arroyo will be commonly used
+    type=click.Choice(["arroyo", "rust_arroyo"]),
+    # TODO: Remove the support for dynamically load the class.
+    # Add a runner CLI in the flink package instead that instantiates
+    # the Flink adapter.
+    help=(
+        "The stream adapter to instantiate. It can be one of the allowed values from "
+        "the load_adapter function"
+    ),
+)
+@click.option(
+    "--config",
+    required=True,
+    help=(
+        "The deployment config file path. Each config file currently corresponds to a specific pipeline."
+    ),
+)
+@click.option(
+    "--segment-id",
+    "-s",
+    type=str,
+    help="The segment id to run the pipeline for",
+)
+@click.argument(
+    "application",
+    required=True,
+)
+def main(
+    name: str,
+    log_level: str,
+    adapter: str,
+    config: str,
+    segment_id: Optional[str],
+    application: str,
+) -> None:
+    runner(name, log_level, adapter, config, segment_id, application)
 
 
 if __name__ == "__main__":

--- a/sentry_streams/uv.lock
+++ b/sentry_streams/uv.lock
@@ -96,6 +96,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -126,6 +138,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/96/25/124e14b20825084e96d1609e1c5d3775d85999f19a688f7487799f0c44b6/confluent_kafka-2.9.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:b21e4a4ba88374a1487a9353debcddc994dae385f89d6bc45f08ab372e238756", size = 3831584, upload-time = "2025-03-28T21:56:57.37Z" },
     { url = "https://files.pythonhosted.org/packages/c0/a2/728bb427df2491eaf811e44b9d68907f68c6a596cc75bf55ca4d780f38d0/confluent_kafka-2.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:a26b91d4d352d4c77727582ec4013fa62814c54618c11f27545a9ce531406a15", size = 4021284, upload-time = "2025-03-28T21:56:59.272Z" },
     { url = "https://files.pythonhosted.org/packages/43/27/3050db41dccf9aae3685906e419e2bfcb59929a3f9826d50111c419ccf8f/confluent_kafka-2.9.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e9408aa82578969123efa27b55e510e752728eb737db748f7c7ab9f18ec5af60", size = 15163212, upload-time = "2025-03-28T21:57:01.417Z" },
+]
+
+[[package]]
+name = "devservices"
+version = "1.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "sentry-devenv" },
+    { name = "sentry-sdk" },
+    { name = "supervisor" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/96/dc48cd924b068628262708918eb68da62a0fd38e1de4440a8206ce78965c/devservices-1.1.5.tar.gz", hash = "sha256:14346e3f0f87d9a4529713fd1631896f9254aa4e59e401900ed2544b5bc70d4b", size = 75465, upload-time = "2025-05-05T22:56:56.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/a9/ddd63131b96a670c2a6bccd1194f5f1acaa1172f36c51f992c51a52a2456/devservices-1.1.5-py3-none-any.whl", hash = "sha256:7150dbdfde3f30abf1505ffc258b296c844bd1da0b47fe054819e0e25ec98a3a", size = 100355, upload-time = "2025-05-05T22:56:54.542Z" },
 ]
 
 [[package]]
@@ -795,6 +823,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-devenv"
+version = "1.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sentry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/ee/368badc81561cbaaf338e6a060c53cad94b628d23359a10eeeea5daa42be/sentry_devenv-1.21.0.tar.gz", hash = "sha256:bd1dbfcda980392e98f03b94314910b84a7413225a07cb2ad8f40a4233f2a3d7", size = 47987, upload-time = "2025-05-21T13:43:32.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/84/46409ceae3eaf88cf8c7fa1f98971a5c36d78f023196473b95c04848b998/sentry_devenv-1.21.0-py3-none-any.whl", hash = "sha256:4005b9121b6aa78c32eaa14e5429ed601c9bfacd90952c51c1f89044c3c3af65", size = 65989, upload-time = "2025-05-21T13:43:31.202Z" },
+]
+
+[[package]]
 name = "sentry-kafka-schemas"
 version = "1.3.14"
 source = { registry = "https://pypi.org/simple" }
@@ -826,16 +867,32 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.32.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/59/eb90c45cb836cf8bec973bba10230ddad1c55e2b2e9ffa9d7d7368948358/sentry_sdk-2.32.0.tar.gz", hash = "sha256:9016c75d9316b0f6921ac14c8cd4fb938f26002430ac5be9945ab280f78bec6b", size = 334932, upload-time = "2025-06-27T08:10:02.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/a1/fc4856bd02d2097324fb7ce05b3021fb850f864b83ca765f6e37e92ff8ca/sentry_sdk-2.32.0-py2.py3-none-any.whl", hash = "sha256:6cf51521b099562d7ce3606da928c473643abe99b00ce4cb5626ea735f4ec345", size = 356122, upload-time = "2025-06-27T08:10:01.424Z" },
+]
+
+[[package]]
 name = "sentry-streams"
 version = "0.0.25"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
+    { name = "devservices" },
     { name = "jsonschema" },
     { name = "polars" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "sentry-arroyo" },
     { name = "sentry-kafka-schemas" },
+    { name = "types-confluent-kafka" },
 ]
 
 [package.dev-dependencies]
@@ -857,12 +914,15 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.2.1" },
+    { name = "devservices", specifier = "==1.1.5" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "polars" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "sentry-arroyo", specifier = ">=2.18.2" },
     { name = "sentry-kafka-schemas", specifier = ">=1.2.0" },
+    { name = "types-confluent-kafka", specifier = ">=1.3.4" },
 ]
 
 [package.metadata.requires-dev]
@@ -880,6 +940,15 @@ docs = [
     { name = "sphinx", specifier = ">=7.2.6" },
     { name = "sphinx-rtd-theme", specifier = ">=1.3.0" },
     { name = "sphinxcontrib-mermaid", specifier = ">=1.0.0" },
+]
+
+[[package]]
+name = "setuptools"
+version = "80.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
 ]
 
 [[package]]
@@ -1010,6 +1079,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
+]
+
+[[package]]
+name = "supervisor"
+version = "4.2.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/37/517989b05849dd6eaa76c148f24517544704895830a50289cbbf53c7efb9/supervisor-4.2.5.tar.gz", hash = "sha256:34761bae1a23c58192281a5115fb07fbf22c9b0133c08166beffc70fed3ebc12", size = 466073, upload-time = "2022-12-24T01:02:43.705Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/7a/0ad3973941590c040475046fef37a2b08a76691e61aa59540828ee235a6e/supervisor-4.2.5-py2.py3-none-any.whl", hash = "sha256:2ecaede32fc25af814696374b79e42644ecaba5c09494c51016ffda9602d0f08", size = 319561, upload-time = "2022-12-24T01:02:40.814Z" },
+]
+
+[[package]]
+name = "types-confluent-kafka"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/61/c41de4995ddca12b65fd5a05da08afc644299bcfd7e4298bc0376a18b30e/types_confluent_kafka-1.3.4.tar.gz", hash = "sha256:043135a9899699df43ab64c669086136b76dd30cfcf8dade2a0140a711d18de0", size = 22719, upload-time = "2025-07-10T05:03:29.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/02b7e450ef98ea1790e8e751c8040a1754285bc7cf77bcd344914a219d6c/types_confluent_kafka-1.3.4-py3-none-any.whl", hash = "sha256:84c14db11d0b9edba7e898d9081d6a8529a0c151fb7288d742bbaf8cbd7bf34d", size = 35597, upload-time = "2025-07-10T05:03:28.077Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This sets up a test framework for doing E2E tests on a pipeline. This test will start the runner in
a subprocess, send the generated messages to the source, and check the outputs are correct.

This also adds a CI job to run these tests.
