### PR TITLE
fix(broadcast): fix issues mentioned in #164

### DIFF
--- a/sentry_streams/src/consumer.rs
+++ b/sentry_streams/src/consumer.rs
@@ -271,8 +271,8 @@ impl ProcessingStrategyFactory<KafkaPayload> for ArroyoStreamingFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fake_strategy::assert_messages_match;
     use crate::fake_strategy::FakeStrategy;
+    use crate::fake_strategy::{assert_messages_match, submitted_payloads};
     use crate::operators::RuntimeOperator;
     use crate::routes::Route;
     use crate::testutils::make_lambda;
@@ -379,8 +379,9 @@ mod tests {
                 .unwrap();
             let expected_messages = vec![value];
             let actual_messages = submitted_messages_clone.lock().unwrap();
+            let actual_payloads = submitted_payloads(actual_messages.deref());
 
-            assert_messages_match(py, expected_messages, actual_messages.deref());
+            assert_messages_match(py, expected_messages, &actual_payloads);
         })
     }
 }

--- a/sentry_streams/src/filter_step.rs
+++ b/sentry_streams/src/filter_step.rs
@@ -84,6 +84,8 @@ impl ProcessingStrategy<RoutedValue> for Filter {
 mod tests {
     use super::*;
     use crate::fake_strategy::assert_messages_match;
+    use crate::fake_strategy::submitted_payloads;
+    use crate::fake_strategy::submitted_watermark_payloads;
     use crate::fake_strategy::FakeStrategy;
     use crate::messages::Watermark;
     use crate::routes::Route;
@@ -270,8 +272,9 @@ mod tests {
                 "test_message".into_py_any(py).unwrap(),
             ];
             let actual_messages = submitted_messages_clone.lock().unwrap();
+            let message_payloads = submitted_payloads(actual_messages.deref());
 
-            assert_messages_match(py, expected_messages, actual_messages.deref());
+            assert_messages_match(py, expected_messages, &message_payloads);
 
             let watermark_val = RoutedValue {
                 route: Route::new(String::from("source"), vec![]),
@@ -281,7 +284,8 @@ mod tests {
             let watermark_res = strategy.submit(watermark_msg);
             assert!(watermark_res.is_ok());
             let watermark_messages = submitted_watermarks_clone.lock().unwrap();
-            assert_eq!(watermark_messages[0], Watermark::new(BTreeMap::new()));
+            let watermark_payloads = submitted_watermark_payloads(watermark_messages.deref());
+            assert_eq!(watermark_payloads[0], Watermark::new(BTreeMap::new()));
         });
     }
 }

--- a/sentry_streams/src/python_operator.rs
+++ b/sentry_streams/src/python_operator.rs
@@ -261,6 +261,7 @@ impl ProcessingStrategy<RoutedValue> for PythonAdapter {
 mod tests {
     use super::*;
     use crate::fake_strategy::assert_messages_match;
+    use crate::fake_strategy::submitted_payloads;
     use crate::fake_strategy::FakeStrategy;
     use crate::messages::{PyWatermark, WatermarkMessage};
     use crate::testutils::build_routed_value;
@@ -459,7 +460,8 @@ class RustOperatorDelegateFactory:
                 let expected_messages =
                     vec!["ok".into_py_any(py).unwrap(), "ok".into_py_any(py).unwrap()];
                 let actual_messages = submitted_messages_clone.lock().unwrap();
-                assert_messages_match(py, expected_messages, actual_messages.deref());
+                let message_payloads = submitted_payloads(actual_messages.deref());
+                assert_messages_match(py, expected_messages, &message_payloads);
             } // Unlock the MutexGuard around `actual_messages`
 
             assert_eq!(
@@ -485,7 +487,8 @@ class RustOperatorDelegateFactory:
                     "ok".into_py_any(py).unwrap(),
                 ];
                 let actual_messages = submitted_messages_clone.lock().unwrap();
-                assert_messages_match(py, expected_messages, actual_messages.deref());
+                let message_payloads = submitted_payloads(actual_messages.deref());
+                assert_messages_match(py, expected_messages, &message_payloads);
             } // Unlock the MutexGuard around `actual_messages`
 
             let watermark_val = RoutedValue {
@@ -535,7 +538,8 @@ class RustOperatorDelegateFactory:
             {
                 let expected_messages = vec![];
                 let actual_messages = submitted_messages_clone.lock().unwrap();
-                assert_messages_match(py, expected_messages, actual_messages.deref());
+                let message_payloads = submitted_payloads(actual_messages.deref());
+                assert_messages_match(py, expected_messages, &message_payloads);
             } // Unlock the MutexGuard around `actual_messages`
         })
     }

--- a/sentry_streams/src/transformer.rs
+++ b/sentry_streams/src/transformer.rs
@@ -69,6 +69,8 @@ pub fn build_filter(
 mod tests {
     use super::*;
     use crate::fake_strategy::assert_messages_match;
+    use crate::fake_strategy::submitted_payloads;
+    use crate::fake_strategy::submitted_watermark_payloads;
     use crate::fake_strategy::FakeStrategy;
     use crate::messages::Watermark;
     use crate::routes::Route;
@@ -244,8 +246,9 @@ mod tests {
                 "test_message".into_py_any(py).unwrap(),
             ];
             let actual_messages = submitted_messages_clone.lock().unwrap();
+            let message_payloads = submitted_payloads(actual_messages.deref());
 
-            assert_messages_match(py, expected_messages, actual_messages.deref());
+            assert_messages_match(py, expected_messages, &message_payloads);
 
             let watermark_val = RoutedValue {
                 route: Route::new(String::from("source"), vec![]),
@@ -255,7 +258,8 @@ mod tests {
             let watermark_res = strategy.submit(watermark_msg);
             assert!(watermark_res.is_ok());
             let watermark_messages = submitted_watermarks_clone.lock().unwrap();
-            assert_eq!(watermark_messages[0], Watermark::new(BTreeMap::new()));
+            let watermark_payloads = submitted_watermark_payloads(watermark_messages.deref());
+            assert_eq!(watermark_payloads[0], Watermark::new(BTreeMap::new()));
         });
     }
 }


### PR DESCRIPTION
Fixes the issues mentioned in comments of https://github.com/getsentry/streams/pull/164.

WIP as I'm getting this error when attempting to call `copy.deepcopy()` on `PyAnyMessage`:
```
---- broadcaster::tests::test_message_rejected stdout ----

thread 'broadcaster::tests::test_message_rejected' panicked at src/messages.rs:333:26:
called `Result::unwrap()` on an `Err` value: PyErr { type: <class 'TypeError'>, value: TypeError("cannot pickle 'builtins.PyAnyMessage' object"), traceback: Some("Traceback (most recent call last):\n  File \"/Users/benmckerry/.local/share/uv/python/cpython-3.11.13-macos-aarch64-none/lib/python3.11/copy.py\", line 161, in deepcopy\n    rv = reductor(4)\n         ^^^^^^^^^^^\n") }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    broadcaster::tests::test_message_rejected

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 41 filtered out; finished in 0.01s
```