### PR TITLE
Decouple the translator from the runner

### DIFF
--- a/sentry_streams/sentry_streams/adapters/arroyo/dumping_consumer.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/dumping_consumer.py
@@ -1,0 +1,203 @@
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Mapping, Sequence
+
+from sentry_streams.adapters.arroyo.routes import Route
+from sentry_streams.config_types import MultiProcessConfig
+from sentry_streams.pipeline.message import Message
+from sentry_streams.pipeline.pipeline import Broadcast, Filter, GCSSink, Reduce, Router
+from sentry_streams.rust_streams import PyKafkaProducerConfig
+
+
+class ArroyoConsumer(ABC):
+    def __init__(self) -> None:
+        self.__chain: Sequence[Mapping[str, Any]] = []
+
+    @abstractmethod
+    def add_gcs_sink(self, step_name: str, route: Route, bucket: str, step: GCSSink) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def add_stream_sink(
+        self, step_name: str, route: Route, stream_name: str, kafka_config: PyKafkaProducerConfig
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def add_map(self, step_name: str, route: Route) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def add_filter(self, step_name: str, route: Route, step: Filter[Any]) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def add_multiprocess_map(
+        self,
+        step_name: str,
+        route: Route,
+        config: MultiProcessConfig,
+        func: Callable[[Message[Any]], Message[Any]],
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def add_broadcast(self, step_name: str, route: Route, step: Broadcast[Any]) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def add_router(self, step_name: str, route: Route, step: Router[Any, Any]) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def add_reduce(self, step_name: str, route: Route, step: Reduce[Any, Any, Any]) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def run(self) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def dump(self) -> Any:
+        raise NotImplementedError
+
+
+class DumpingConsumer(ArroyoConsumer):
+    """
+    A consumer that generates YAML descriptions instead of building actual consumers.
+    This is useful for debugging and understanding pipeline configurations.
+    """
+
+    def __init__(self, source: str, kafka_config: Any, topic: str, schema: str | None) -> None:
+        super().__init__()
+        self.source = source
+        self.kafka_config = kafka_config
+        self.topic = topic
+        self.schema = schema
+        self.steps: list[dict[str, Any]] = []
+
+    def add_gcs_sink(self, step_name: str, route: Route, bucket: str, step: GCSSink) -> None:
+        """Add a GCS sink step to the YAML description."""
+        step_description = {
+            "type": "gcs_sink",
+            "step_name": step_name,
+            "route": {"source": route.source, "waypoints": route.waypoints},
+            "bucket": bucket,
+            "object_generator": str(step.object_generator),
+        }
+        self.steps.append(step_description)
+
+    def add_stream_sink(
+        self, step_name: str, route: Route, stream_name: str, kafka_config: PyKafkaProducerConfig
+    ) -> None:
+        """Add a stream sink step to the YAML description."""
+        step_description = {
+            "type": "stream_sink",
+            "step_name": step_name,
+            "route": {"source": route.source, "waypoints": route.waypoints},
+            "stream_name": stream_name,
+            "kafka_config": {
+                "bootstrap_servers": kafka_config.bootstrap_servers,
+                "override_params": (
+                    dict(kafka_config.override_params) if kafka_config.override_params else {}
+                ),
+            },
+        }
+        self.steps.append(step_description)
+
+    def add_map(self, step_name: str, route: Route) -> None:
+        """Add a map step to the YAML description."""
+        step_description = {
+            "type": "map",
+            "step_name": step_name,
+            "route": {"source": route.source, "waypoints": route.waypoints},
+        }
+        self.steps.append(step_description)
+
+    def add_filter(self, step_name: str, route: Route, step: Filter[Any]) -> None:
+        """Add a filter step to the YAML description."""
+        step_description = {
+            "type": "filter",
+            "step_name": step_name,
+            "route": {"source": route.source, "waypoints": route.waypoints},
+        }
+        self.steps.append(step_description)
+
+    def add_multiprocess_map(
+        self,
+        step_name: str,
+        route: Route,
+        config: MultiProcessConfig,
+        func: Callable[[Message[Any]], Message[Any]],
+    ) -> None:
+        """Add a multiprocess map step to the YAML description."""
+        step_description = {
+            "type": "multiprocess_map",
+            "step_name": step_name,
+            "route": {"source": route.source, "waypoints": route.waypoints},
+            "config": {
+                "batch_size": config["batch_size"],
+                "batch_time": config["batch_time"],
+                "processes": config["processes"],
+                "input_block_size": config.get("input_block_size"),
+                "output_block_size": config.get("output_block_size"),
+                "max_input_block_size": config.get("max_input_block_size"),
+                "max_output_block_size": config.get("max_output_block_size"),
+            },
+        }
+        self.steps.append(step_description)
+
+    def add_broadcast(self, step_name: str, route: Route, step: Broadcast[Any]) -> None:
+        """Add a broadcast step to the YAML description."""
+        step_description = {
+            "type": "broadcast",
+            "step_name": step_name,
+            "route": {"source": route.source, "waypoints": route.waypoints},
+            "downstream_routes": [branch.root.name for branch in step.routes],
+        }
+        self.steps.append(step_description)
+
+    def add_router(self, step_name: str, route: Route, step: Router[Any, Any]) -> None:
+        """Add a router step to the YAML description."""
+        step_description = {
+            "type": "router",
+            "step_name": step_name,
+            "route": {"source": route.source, "waypoints": route.waypoints},
+            "downstream_routes": [branch.root.name for branch in step.routing_table.values()],
+        }
+        self.steps.append(step_description)
+
+    def add_reduce(self, step_name: str, route: Route, step: Reduce[Any, Any, Any]) -> None:
+        """Add a reduce step to the YAML description."""
+        step_description = {
+            "type": "reduce",
+            "step_name": step_name,
+            "route": {"source": route.source, "waypoints": route.waypoints},
+        }
+        self.steps.append(step_description)
+
+    def run(self) -> None:
+        """This method does nothing for the dumping consumer."""
+        pass
+
+    def dump(self) -> dict[str, Any]:
+        """Return the complete YAML description of the consumer."""
+        return {
+            "consumer": {
+                "source": self.source,
+                "topic": self.topic,
+                "schema": self.schema,
+                "kafka_config": {
+                    "bootstrap_servers": self.kafka_config.bootstrap_servers,
+                    "group_id": self.kafka_config.group_id,
+                    "auto_offset_reset": str(self.kafka_config.auto_offset_reset),
+                    "strict_offset_reset": self.kafka_config.strict_offset_reset,
+                    "max_poll_interval_ms": self.kafka_config.max_poll_interval_ms,
+                    "override_params": (
+                        dict(self.kafka_config.override_params)
+                        if self.kafka_config.override_params
+                        else {}
+                    ),
+                },
+                "steps": self.steps,
+            }
+        }

--- a/sentry_streams/sentry_streams/adapters/arroyo/rust_consumer.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/rust_consumer.py
@@ -1,0 +1,116 @@
+from typing import Any, Callable
+
+from arroyo.processing.strategies.run_task_with_multiprocessing import (
+    MultiprocessingPool,
+)
+
+from sentry_streams.adapters.arroyo.dumping_consumer import ArroyoConsumer
+from sentry_streams.adapters.arroyo.multi_process_delegate import (
+    MultiprocessDelegateFactory,
+)
+from sentry_streams.adapters.arroyo.reduce_delegate import ReduceDelegateFactory
+from sentry_streams.adapters.arroyo.routes import Route
+from sentry_streams.config_types import MultiProcessConfig
+from sentry_streams.pipeline.message import Message
+from sentry_streams.pipeline.pipeline import (
+    Broadcast,
+    Filter,
+    GCSSink,
+    Map,
+    Reduce,
+    Router,
+)
+from sentry_streams.rust_streams import ArroyoConsumer as RustNativeArroyoConsumer
+from sentry_streams.rust_streams import (
+    PyKafkaConsumerConfig,
+    PyKafkaProducerConfig,
+)
+from sentry_streams.rust_streams import Route as RustRoute
+from sentry_streams.rust_streams import (
+    RuntimeOperator,
+)
+
+
+class RustArroyoConsumer(ArroyoConsumer):
+
+    def __init__(
+        self, source: str, kafka_config: PyKafkaConsumerConfig, topic: str, schema: str | None
+    ) -> None:
+        self.__consumer = RustNativeArroyoConsumer(source, kafka_config, topic, schema)
+
+    def add_gcs_sink(self, step_name: str, route: Route, bucket: str, step: GCSSink) -> None:
+        self.__consumer.add_step(RuntimeOperator.GCSSink(route, bucket, step.object_generator))
+
+    def add_stream_sink(
+        self, step_name: str, route: Route, stream_name: str, kafka_config: PyKafkaProducerConfig
+    ) -> None:
+        self.__consumer.add_step(RuntimeOperator.StreamSink(route, stream_name, kafka_config))
+
+    def add_map(self, step_name: str, route: Route, step: Map[Any, Any]) -> None:
+        pass
+
+    def add_filter(self, step_name: str, route: Route, step: Filter[Any]) -> None:
+        def filter_msg(msg: Message[Any]) -> bool:
+            return step.resolved_function(msg)
+
+        self.__consumer.add_step(RuntimeOperator.Filter(route, filter_msg))
+
+    def add_multiprocess_map(
+        self,
+        step_name: str,
+        route: Route,
+        config: MultiProcessConfig,
+        func: Callable[[Message[Any]], Message[Any]],
+    ) -> None:
+        self.__consumer.add_step(
+            RuntimeOperator.PythonAdapter(
+                RustRoute(route.source, route.waypoints),
+                MultiprocessDelegateFactory(
+                    func,
+                    config["batch_size"],
+                    config["batch_time"],
+                    MultiprocessingPool(
+                        num_processes=config["processes"],
+                    ),
+                    input_block_size=config.get("input_block_size"),
+                    output_block_size=config.get("output_block_size"),
+                    max_input_block_size=config.get("max_input_block_size"),
+                    max_output_block_size=config.get("max_output_block_size"),
+                ),
+            )
+        )
+
+    def add_broadcast(self, step_name: str, route: Route, step: Broadcast[Any]) -> None:
+        self.__consumer.add_step(
+            RuntimeOperator.Broadcast(
+                RustRoute(route.source, route.waypoints),
+                downstream_routes=[branch.root.name for branch in step.routes],
+            )
+        )
+
+    def add_router(self, step_name: str, route: Route, step: Router[Any, Any]) -> None:
+        def routing_function(msg: Message[Any]) -> str:
+            waypoint = step.routing_function(msg)
+            branch = step.routing_table[waypoint]
+            return branch.root.name
+
+        self.__consumer.add_step(
+            RuntimeOperator.Router(
+                RustRoute(route.source, route.waypoints),
+                routing_function,
+                downstream_routes=[branch.root.name for branch in step.routing_table.values()],
+            )
+        )
+
+    def add_reduce(self, step_name: str, route: Route, step: Reduce[Any, Any, Any]) -> None:
+        self.__consumer.add_step(
+            RuntimeOperator.PythonAdapter(
+                RustRoute(route.source, route.waypoints), ReduceDelegateFactory(step)
+            )
+        )
+
+    def run(self) -> None:
+        self.__consumer.run()
+
+    def dump(self) -> Any:
+        raise NotImplementedError

--- a/sentry_streams/sentry_streams/adapters/loader.py
+++ b/sentry_streams/sentry_streams/adapters/loader.py
@@ -54,6 +54,12 @@ def load_adapter(
 
         # TODO: Fix this type as above.
         return cast(StreamAdapter[Stream, Sink], RustArroyoAdapter.build(config))
+
+    if adapter_type == "dumping_arroyo":
+        from sentry_streams.adapters.arroyo.rust_arroyo import DumpingArroyoAdapter
+
+        # TODO: Fix this type as above.
+        return cast(StreamAdapter[Stream, Sink], DumpingArroyoAdapter.build(config))
     else:
         mod, cls = adapter_type.rsplit(".", 1)
 

--- a/sentry_streams/sentry_streams/runner_config.py
+++ b/sentry_streams/sentry_streams/runner_config.py
@@ -1,0 +1,108 @@
+import importlib
+import json
+import logging
+import signal
+from typing import Any, Optional, cast
+
+import click
+import jsonschema
+import yaml
+
+from sentry_streams.adapters.loader import load_adapter
+from sentry_streams.adapters.stream_adapter import (
+    RuntimeTranslator,
+    StreamSinkT,
+    StreamT,
+)
+from sentry_streams.pipeline.pipeline import (
+    Pipeline,
+    WithInput,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.option(
+    "--name",
+    "-n",
+    default="Sentry Streams Config",
+    show_default=True,
+    help="The name of the Sentry Streams application",
+)
+@click.option(
+    "--log-level",
+    "-l",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
+    default="INFO",
+    show_default=True,
+    help="Set the logging level",
+)
+@click.option(
+    "--pipeline-structure",
+    required=True,
+    help=(
+        "The YAML config file path containing the pipeline definition from DumpingConsumer.dump()."
+    ),
+)
+@click.option(
+    "--segment-id",
+    "-s",
+    type=str,
+    help="The segment id to run the pipeline for",
+)
+@click.argument(
+    "application",
+    required=True,
+)
+def runner_config(
+    name: str,
+    log_level: str,
+    config: str,
+    segment_id: Optional[str],
+    application: str,
+) -> None:
+    pipeline_globals: dict[str, Any] = {}
+
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    # Load the pipeline definition from the Python file
+    with open(application) as f:
+        exec(f.read(), pipeline_globals)
+
+    # Load the YAML config file containing the pipeline definition from DumpingConsumer.dump()
+    with open(config, "r") as config_file:
+        pipeline_config = yaml.safe_load(config_file)
+
+    pipeline: Pipeline[Any] = pipeline_globals["pipeline"]
+    
+    # TODO: Now you have the YAML file that represent the topology of the pipeline.
+    # This would allow you to build the Rust consumer except that the YAML file
+    # cannot contain the Python application functions to be passed to the Rust consumer.
+    # Those have to be loaded dynamically and added to the Consumer in Rust via
+    # RuntimeOperator.
+    # Whether this runner is implemented in Python or Rust python code has to be executed
+    # to obtain references to those functions. Which is fine as they are used only in
+    # hybrid or Python pipelines so we are already executing in a python interpreter there.
+    #
+    # The Python application functions can be loaded from the pipeline graph `pipeline_globals`.
+    # They are referenced in each step. The YAML file contains the name opf the step for each step.
+
+
+def main(
+    name: str,
+    log_level: str,
+    adapter: str,
+    config: str,
+    segment_id: Optional[str],
+    application: str,
+) -> None:
+    runner_config(name, log_level, adapter, config, segment_id, application)
+
+
+if __name__ == "__main__":
+    main() 


### PR DESCRIPTION
This is a sketch of how we could decouple the runner from the DSL
and from the code that processes the pipeline before handing it
to the runtime.

Decoupling is meant to allow us to have a fully rust runner without
having to port DSL and transaltion to Rust. Having a fully Rust
runner can help us to have a simpler way to build hybrid applicaiton
and to use the same runner to run fully Rust applications.

Running a streaming application consists of three components:
1. The DSL used to represent the pipeline structure. We have a Pyhton
   one today. Likely we will have more, though they will all produce
   the same graph structure.
2. Translation. This is a process where the pipeline is handed step
   by step to an Adapter to run it. In this process we are also
   transforming some steps from higher level primitives into a
   small number of low level ones. Example here is where a `Parser`
   step becomes a `Map` step. 
3. Runtime. This is the component that runs the consumer built via
   the adapter at step 2.


The idea in this PR ios that we can run 1 and 2 in Python, then produce
a low level description of the pipeline that we dump in a config file,
then we hand the config file to the Rust runner which can autonomously 
run the pipeline.

So:
1. Introduce the an abstraction layer in between `rust_arroyo.py` and the runtime.
   This can be found as `ArroyoConsumer` in dumping_consumer.py.
2. There are two implementations: one does what the system was doing before
   and creates an Arroyo Consumer. The other accumulates all the parameters
   and then dumps them in a YAML file. 
3. Add a new runner that loads the YAML file that mimics what a rust runner would do.
4. The runner still has to instantiate the python pipeline in hybrid applications
   to get a reference to the python functions to run. Though this is not 
   needed for rust only applications.


Caveats and different directions:
1. nothing works, this is just a sketch.
2. I think we may get away with something simpler. In hybrid applications 
   we are likely to start the rust runner from a python interpreter anyway.
   this allows the application developer to package the application logic
   in the same crate as the runner. Though, since we are starting it from
   a pyhton interpreter, we do not need to dump the application first.
   we can still run the translator.
   The dump would still be needed for fully rust applications.

