### PR TITLE
fix(reduce): test that the right committable is submitted

### DIFF
--- a/sentry_streams/sentry_streams/adapters/arroyo/reduce.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/reduce.py
@@ -177,13 +177,12 @@ class TimeWindowedReduce(
             merged_window.merge(acc)
 
         payload = merged_window.get_value()
-        # We only pass on the offsets from the first acc as it's the one being dropped,
-        # meaning those offsets are safe to commit
-        offsets_to_commit = self.accs[first_acc_id].get_offsets()
 
         # If there is a gap in the data, it is possible to have empty flushes
         if payload:
-            self.msg_wrap_step.submit(Message(Value(cast(TResult, payload), offsets_to_commit)))
+            self.msg_wrap_step.submit(
+                Message(Value(cast(TResult, payload), merged_window.get_offsets()))
+            )
 
         # Refresh only the accumulator that was the first
         # accumulator in the flushed window

--- a/sentry_streams/sentry_streams/adapters/arroyo/reduce.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/reduce.py
@@ -177,12 +177,13 @@ class TimeWindowedReduce(
             merged_window.merge(acc)
 
         payload = merged_window.get_value()
+        # We only pass on the offsets from the first acc as it's the one being dropped,
+        # meaning those offsets are safe to commit
+        offsets_to_commit = self.accs[first_acc_id].get_offsets()
 
         # If there is a gap in the data, it is possible to have empty flushes
         if payload:
-            self.msg_wrap_step.submit(
-                Message(Value(cast(TResult, payload), merged_window.get_offsets()))
-            )
+            self.msg_wrap_step.submit(Message(Value(cast(TResult, payload), offsets_to_commit)))
 
         # Refresh only the accumulator that was the first
         # accumulator in the flushed window

--- a/sentry_streams/tests/adapters/arroyo/test_reduce.py
+++ b/sentry_streams/tests/adapters/arroyo/test_reduce.py
@@ -6,7 +6,7 @@ from unittest.mock import call
 
 import pytest
 from arroyo.processing.strategies.abstract import ProcessingStrategy
-from arroyo.types import BrokerValue, Message, Partition, Topic
+from arroyo.types import BrokerValue, Message, Partition, Topic, Value
 
 from sentry_streams.adapters.arroyo.reduce import (
     TimeWindowedReduce,
@@ -91,17 +91,30 @@ def test_submit_and_poll() -> None:
         next_step=next_step,
         route=route,
     )
+    # fix start_time so we can control what acc a message goes to
+    reduce.start_time = 0
 
-    cur_time = time.time()
+    cur_time = 0
 
-    reduce.submit(make_msg("test-payload", route, 0))
-    reduce.submit(make_msg("test-payload", route, 1))
-    reduce.submit(make_msg("test-payload", route, 2))
+    # first 2 payloads go to acc_id 0
+    with mock.patch("time.time", return_value=cur_time):
+        reduce.submit(make_msg("test-payload", route, 0))
+        reduce.submit(make_msg("test-payload", route, 1))
 
+    # next payload goes to acc_id 1
+    with mock.patch("time.time", return_value=cur_time + 2.0):
+        reduce.submit(make_msg("test-payload", route, 2))
+
+    # poll flushes the current window, should only submit committable for
+    # messages in acc_id 0
     with mock.patch("time.time", return_value=cur_time + 6.0):
         reduce.poll()
 
-    next_step.submit.assert_called_once()
+    # BrokerMessage adds 1 to the committable offset for some reason, so
+    # offset 2 here corresponds to the 2nd message submitted above
+    expected = Message(Value(mock.ANY, {Partition(Topic("test_topic"), 0): 2}))
+
+    next_step.submit.assert_called_once_with(expected)
     next_step.poll.assert_called_once()
 
 

--- a/sentry_streams/tests/adapters/arroyo/test_reduce.py
+++ b/sentry_streams/tests/adapters/arroyo/test_reduce.py
@@ -84,15 +84,14 @@ def test_submit_and_poll() -> None:
     acc = mock.Mock(spec=Accumulator)
     route = mock.Mock(spec=Route)
 
-    reduce: TimeWindowedReduce[Any, Any] = TimeWindowedReduce(
-        window_size=6.0,
-        window_slide=2.0,
-        acc=acc,
-        next_step=next_step,
-        route=route,
-    )
-    # fix start_time so we can control what acc a message goes to
-    reduce.start_time = 0
+    with mock.patch("time.time", return_value=0):
+        reduce: TimeWindowedReduce[Any, Any] = TimeWindowedReduce(
+            window_size=6.0,
+            window_slide=2.0,
+            acc=acc,
+            next_step=next_step,
+            route=route,
+        )
 
     cur_time = 0
 


### PR DESCRIPTION
This PR updates `test_submit_and_poll` in test_reduce to check that the committable received when closing a sliding window is the correct one (i.e. only the committable of messages in the accumulator that's being closed)