### PR TITLE
expose thread_count to GCSSink

### DIFF
--- a/sentry_streams/sentry_streams/adapters/arroyo/rust_arroyo.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/rust_arroyo.py
@@ -202,14 +202,20 @@ class RustArroyoAdapter(StreamAdapter[Route, Route]):
                 bucket = (
                     step.bucket if not sink_config.get("bucket") else str(sink_config.get("bucket"))
                 )
+                parallelism_config = cast(Mapping[str, Any], sink_config.get("parallelism"))
+                if parallelism_config:
+                    thread_count = cast(int, parallelism_config["threads"])
+                else:
+                    thread_count = 1
             else:
                 bucket = step.bucket
+                thread_count = 1
 
             object_generator = step.object_generator
 
             logger.info(f"Adding GCS sink: {step.name} to pipeline")
             self.__consumers[stream.source].add_step(
-                RuntimeOperator.GCSSink(route, bucket, object_generator)
+                RuntimeOperator.GCSSink(route, bucket, object_generator, thread_count)
             )
 
         # Our fallback for now since there's no other Sink type

--- a/sentry_streams/sentry_streams/rust_streams.pyi
+++ b/sentry_streams/sentry_streams/rust_streams.pyi
@@ -51,7 +51,9 @@ class RuntimeOperator:
         cls, route: Route, topic_name: str, kafka_config: PyKafkaProducerConfig
     ) -> Self: ...
     @classmethod
-    def GCSSink(cls, route: Route, bucket: str, object_generator: Callable[[], str]) -> Self: ...
+    def GCSSink(
+        cls, route: Route, bucket: str, object_generator: Callable[[], str], thread_count: int
+    ) -> Self: ...
     @classmethod
     def Router(
         cls, route: Route, function: Callable[[Message[Any]], str], downstream_routes: Sequence[str]


### PR DESCRIPTION
adds the `thread_count` arg to GCSSink without doing anything with it. This PR simply wires it up so that when https://linear.app/getsentry/issue/STREAM-338/support-multiple-concurrencyconfig-object-in-rust this ticket is done `GCSSink` can start using it