### PR TITLE
ref: move make_msg functions into message_helpers.py

### DIFF
--- a/sentry_streams/tests/adapters/arroyo/message_helpers.py
+++ b/sentry_streams/tests/adapters/arroyo/message_helpers.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any
+from typing import Any, Tuple
 
 from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.types import (
@@ -12,6 +12,8 @@ from arroyo.types import (
 )
 
 from sentry_streams.adapters.arroyo.routes import Route, RoutedValue
+from sentry_streams.adapters.arroyo.rust_step import Committable
+from sentry_streams.pipeline.message import PyMessage, RustMessage
 
 TEST_PARTITION = Partition(Topic("test_topic"), 0)
 
@@ -78,4 +80,21 @@ def make_kafka_msg(
             offset=offset,
             timestamp=datetime.now(),
         )
+    )
+
+
+def build_rust_msg(payload: str, timestamp: float, offset: int) -> Tuple[RustMessage, Committable]:
+    msg, committable = build_py_msg(payload, timestamp, offset)
+    return (msg.to_inner(), committable)
+
+
+def build_py_msg(payload: str, timestamp: float, offset: int) -> Tuple[PyMessage[str], Committable]:
+    return (
+        PyMessage(
+            payload=payload,
+            headers=[],
+            timestamp=timestamp,
+            schema="ingest-metrics",
+        ),
+        {("test_topic", 0): offset},
     )


### PR DESCRIPTION
This moves `test_reduce_delegate`'s helper functions for making messages into our message test helper module.
I'm going to be re-using these in a future PR for tests.