### PR TITLE
feat(rust): Provide a rust runner to start consumer in CLI in rust

### DIFF
--- a/sentry_streams/Cargo.lock
+++ b/sentry_streams/Cargo.lock
@@ -42,6 +42,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +184,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
 name = "cmake"
 version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +242,12 @@ dependencies = [
  "wasix",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation"
@@ -713,6 +809,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,6 +1012,12 @@ name = "once_cell"
 version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2806eaa3524762875e21c3dcd057bc4b7bfa01ce4da8d46be1cd43649e1cc6b"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openssl"
@@ -1301,6 +1409,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "clap",
  "ctrlc",
  "log",
  "parking_lot",
@@ -1666,6 +1775,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -2047,6 +2162,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/sentry_streams/Cargo.toml
+++ b/sentry_streams/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-pyo3 = { version = "0.24.0"}
+pyo3 = { version = "0.24.0" }
 serde = { version = "1.0", features = ["derive"] }
 sentry_arroyo = "2.19.5"
 chrono = "0.4.40"
@@ -17,6 +17,7 @@ reqwest = "0.12.15"
 tokio = "1.45.0"
 log = "0.4.27"
 serde_json = "1.0.141"
+clap = { version = "4.5.45", features = ["derive"], optional = true }
 
 [lib]
 name = "rust_streams"
@@ -24,6 +25,7 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 extension-module = ["pyo3/extension-module"]
+cli = ["dep:clap", "pyo3/auto-initialize"]
 
 [dev-dependencies]
 parking_lot = "0.12.1"

--- a/sentry_streams/sentry_streams/examples/rust_simple_map_filter/rust_transforms/Cargo.lock
+++ b/sentry_streams/sentry_streams/examples/rust_simple_map_filter/rust_transforms/Cargo.lock
@@ -33,6 +33,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +175,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
 name = "cmake"
 version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +233,12 @@ dependencies = [
  "wasix",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation"
@@ -659,6 +755,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +969,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openssl"
@@ -1251,6 +1359,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "clap",
  "ctrlc",
  "log",
  "pyo3",
@@ -1512,6 +1621,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1904,6 +2019,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/sentry_streams/sentry_streams/examples/rust_simple_map_filter/rust_transforms/Cargo.toml
+++ b/sentry_streams/sentry_streams/examples/rust_simple_map_filter/rust_transforms/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 name = "metrics_rust_transforms"
 crate-type = ["cdylib"]
 
+[[bin]]
+name = "runner"
+path = "src/main.rs"
+
 [dependencies]
 pyo3 = { version = "0.24" }
 serde = { version = "1.0", features = ["derive"] }
@@ -20,3 +24,4 @@ serde_json = "1.0"
 [dependencies.rust_streams]
 path = "../../../../"  # Point to the main rust_streams crate
 default-features = false  # Disable default features to avoid loading pyo3 a second time
+features = ["cli"]

--- a/sentry_streams/sentry_streams/examples/rust_simple_map_filter/rust_transforms/src/main.rs
+++ b/sentry_streams/sentry_streams/examples/rust_simple_map_filter/rust_transforms/src/main.rs
@@ -1,0 +1,9 @@
+use std::error::Error;
+
+use rust_streams::run::{run, Args};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::parse();
+
+    run(args)
+}

--- a/sentry_streams/src/lib.rs
+++ b/sentry_streams/src/lib.rs
@@ -25,6 +25,8 @@ mod watermark;
 #[doc(hidden)]
 pub mod ffi;
 pub use ffi::Message;
+#[cfg(feature = "cli")]
+pub mod run;
 
 #[cfg(test)]
 mod fake_strategy;

--- a/sentry_streams/src/run.rs
+++ b/sentry_streams/src/run.rs
@@ -1,0 +1,100 @@
+use std::ffi::OsString;
+
+use clap::Parser;
+use pyo3::prelude::*;
+
+use crate::utils::traced_with_gil;
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    #[command(flatten)]
+    pub py_config: PyConfig,
+
+    #[command(flatten)]
+    pub runtime_config: RuntimeConfig,
+}
+
+impl Args {
+    pub fn parse() -> Self {
+        Parser::parse()
+    }
+}
+
+#[derive(Parser, Debug)]
+pub struct PyConfig {
+    /// Path of the python interpreter executable
+    #[arg(short, long)]
+    pub exec_path: Option<OsString>,
+
+    #[arg(short, long)]
+    /// Paths to the relevant python modules
+    pub module_paths: Option<Vec<OsString>>,
+}
+
+#[derive(Parser, Debug)]
+pub struct RuntimeConfig {
+    /// The name of the Sentry Streams application
+    #[arg(short, long)]
+    pub name: String,
+
+    /// The name of the Sentry Streams application
+    #[arg(short, long)]
+    pub log_level: String,
+
+    /// The name of the adapter
+    #[arg(short, long)]
+    pub adapter_name: String,
+
+    /// The deployment config file path. Each config file currently corresponds to a specific pipeline.
+    #[arg(short, long)]
+    pub config_file: OsString,
+
+    /// The segment id to run the pipeline for
+    #[arg(short, long)]
+    pub segment_id: Option<String>,
+
+    /// The name of the application
+    pub application_name: String,
+}
+
+pub fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    let Args {
+        py_config,
+        runtime_config,
+    } = args;
+
+    traced_with_gil!(|py| -> PyResult<()> {
+        if let Some(exec_path) = py_config.exec_path {
+            PyModule::import(py, "sys")?.setattr("executable", exec_path)?;
+        }
+        if let Some(module_paths) = py_config.module_paths {
+            PyModule::import(py, "sys")?.setattr("path", module_paths)?;
+        }
+        Ok(())
+    })?;
+
+    let runtime: Py<PyAny> = traced_with_gil!(|py| {
+        let runtime = py
+            .import("sentry_streams.runner")?
+            .getattr("load_runtime")?
+            .call1((
+                runtime_config.name,
+                runtime_config.log_level,
+                runtime_config.adapter_name,
+                runtime_config.config_file,
+                runtime_config.segment_id,
+                runtime_config.application_name,
+            ))?
+            .unbind();
+        PyResult::Ok(runtime)
+    })?;
+
+    traced_with_gil!(|py| {
+        runtime
+            .bind(py)
+            .call_method0("run")
+            .expect("Unable to start runtime");
+    });
+
+    Ok(())
+}


### PR DESCRIPTION
Provides a way to let users to start their pipeline in rust.

Also added some argument parsing facilities that lets users to build CLI easily.

i.e.
```rust
use std::error::Error;

use rust_streams::run::{run, Args};

fn main() -> Result<(), Box<dyn Error>> {
    let args = Args::parse();

    run(args)
}
```

```bash
cargo run -- \
	--config-file ~/code/streams/sentry_streams/sentry_streams/deployment_config/simple_batching.yaml \
	--segment-id 0 \
	--adapter-name rust_arroyo \
	--exec-path ../../../../.venv/bin/python \
	--module-paths ../../../../.venv/bin/python \
	--module-paths ../../../../ \
	--module-paths ../../../../.venv/lib/python3.11/site-packages \
	--module-paths /opt/homebrew/Cellar/python@3.11/3.11.12_1/Frameworks/Python.framework/Versions/3.11/lib/python311.zip \
	--module-paths /opt/homebrew/Cellar/python@3.11/3.11.12_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11 \
	--module-paths /opt/homebrew/Cellar/python@3.11/3.11.12_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload \
	~/code/streams/sentry_streams/sentry_streams/examples/simple_batching.py
```

They can also start the pipeline programmatically should they chose to
```rust
use std::error::Error;
use rust_streams::run::{run, Args};

fn main() -> Result<(), Box<dyn Error>> {
    run(Args {
        // settings here
    })
}
```