### PR TITLE
fix(watermark): add specific func signature

### DIFF
--- a/sentry_streams/sentry_streams/adapters/arroyo/rust_step.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/rust_step.py
@@ -332,6 +332,8 @@ class ArroyoStrategyDelegate(RustOperatorDelegate, Generic[TStrategyIn, TStrateg
         self.__inner.poll()
         return self.__yield_messages()
 
-    def flush(self, timeout: float | None = None) -> Iterable[Tuple[PipelineMessage, Committable]]:
+    def flush(
+        self, timeout: float | None = None
+    ) -> MutableSequence[Tuple[PipelineMessage, Committable]]:
         self.__inner.join(timeout)
         return self.__yield_messages()


### PR DESCRIPTION
followup to [PR ](https://github.com/getsentry/streams/pull/203), the submit function needs a more specific return type, because the caller in pyo3 in rust needs a list