### PR TITLE
downgrade click

### DIFF
--- a/sentry_streams/pyproject.toml
+++ b/sentry_streams/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "jsonschema>=4.23.0",
     "sentry-kafka-schemas>=1.2.0",
     "polars",
-    "click>=8.2.1",
+    "click>=8.1.7",
     "datadog>=0.52.0",
 ]
 

--- a/sentry_streams/uv.lock
+++ b/sentry_streams/uv.lock
@@ -927,7 +927,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8.2.1" },
+    { name = "click", specifier = ">=8.1.7" },
     { name = "datadog", specifier = ">=0.52.0" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "polars" },


### PR DESCRIPTION
sbc uses 8.1.8 and snuba uses 8.1.7, sentry uses 8.2.1