### PR TITLE
chore: Remove create-pr skill alias from agents.toml

### DIFF
--- a/agents.toml
+++ b/agents.toml
@@ -18,10 +18,6 @@ name = "create-branch"
 source = "getsentry/skills"
 
 [[skills]]
-name = "create-pr"
-source = "getsentry/skills"
-
-[[skills]]
 name = "iterate-pr"
 source = "getsentry/skills"
 


### PR DESCRIPTION
The `create-pr` skill no longer exists in `getsentry/skills` — it was removed and replaced by `pr-writer`, which is already declared as a dependency in `agents.toml`. This caused `git pull` to fail with a resolution error.

Removes the stale `create-pr` entry to fix the error.