### PR TITLE
Reduce the impact of metrics on throughput

### DIFF
--- a/sentry_streams/sentry_streams/adapters/arroyo/rust_arroyo.py
+++ b/sentry_streams/sentry_streams/adapters/arroyo/rust_arroyo.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import random
 import time
 from dataclasses import replace
 from typing import (
@@ -39,7 +40,6 @@ from sentry_streams.metrics import (
     MetricsConfig,
     configure_metrics,
     get_metrics,
-    get_size,
 )
 from sentry_streams.pipeline.function_template import (
     InputType,
@@ -97,47 +97,50 @@ def initializer(metrics_config: MetricsConfig) -> None:
 
 
 def _metrics_wrapped_function(
-    step_name: str, application_function: Callable[[Message[Any]], Any], msg: Message[Any]
+    step_name: str,
+    sample_rate: float,
+    application_function: Callable[[Message[Any]], Any],
+    msg: Message[Any],
 ) -> Any:
     """
     Module-level wrapper function for adding metrics to step functions.
     This is defined at module level to be picklable for multiprocessing.
     """
-    msg_size = get_size(msg.payload) if hasattr(msg, "payload") else None
-    start_time = input_metrics(step_name, msg_size)
-    has_error = output_size = None
+    input_metrics(step_name, sample_rate)
+    has_error = None
+    start_time = time.time()
     try:
         result = application_function(msg)
-        output_size = get_size(result)
         return result
     except Exception as e:
         has_error = str(e.__class__.__name__)
         raise e
     finally:
-        output_metrics(step_name, has_error, start_time, output_size)
+        output_metrics(step_name, has_error, start_time, sample_rate)
 
 
-def input_metrics(name: str, message_size: int | None) -> float:
+def input_metrics(name: str, sample_rate: float) -> None:
+    if random.random() > sample_rate:
+        return
     metrics = get_metrics()
     tags = {"step": name}
-    metrics.increment(Metric.INPUT_MESSAGES, tags=tags)
-    if message_size is not None:
-        metrics.increment(Metric.INPUT_BYTES, tags=tags, value=message_size)
-    return time.time()
+    metrics.increment(Metric.INPUT_MESSAGES, value=1 / sample_rate, tags=tags)
 
 
 def output_metrics(
-    name: str, error: str | None, start_time: float, message_size: int | None
+    name: str,
+    error: str | None,
+    start_time: float,
+    sample_rate: float,
 ) -> None:
+    if random.random() > sample_rate:
+        return
     metrics = get_metrics()
     tags = {"step": name}
     if error:
         tags["error"] = error
         metrics.increment(Metric.ERRORS, tags=tags)
 
-    metrics.increment(Metric.OUTPUT_MESSAGES, tags=tags)
-    if message_size is not None:
-        metrics.increment(Metric.OUTPUT_BYTES, tags=tags, value=message_size)
     metrics.timing(Metric.DURATION, time.time() - start_time, tags=tags)
 
 
@@ -237,6 +240,7 @@ class RustArroyoAdapter(StreamAdapter[Route, Route]):
         steps_config: Mapping[str, StepConfig],
         metrics_config: MetricsConfig,
         write_healthcheck: bool = False,
+        metrics_sample_rate: float = 0.1,
     ) -> None:
         super().__init__()
         self.steps_config = steps_config
@@ -244,6 +248,7 @@ class RustArroyoAdapter(StreamAdapter[Route, Route]):
         self.__write_healthcheck = write_healthcheck
         self.__consumers: MutableMapping[str, ArroyoConsumer] = {}
         self.__chains = TransformChains()
+        self.__metrics_sample_rate = metrics_sample_rate
 
     @classmethod
     def build(  # type: ignore[override]
@@ -255,8 +260,9 @@ class RustArroyoAdapter(StreamAdapter[Route, Route]):
         adapter_config = config.get("adapter_config") or {}
         arroyo_config = adapter_config.get("arroyo") or {}
         write_healthcheck = bool(arroyo_config.get("write_healthcheck", False))
+        metrics_sample_rate = float(arroyo_config.get("metrics_sample_rate", 0.1))
 
-        return cls(steps_config, metrics_config, write_healthcheck)
+        return cls(steps_config, metrics_config, write_healthcheck, metrics_sample_rate)
 
     def __close_chain(self, stream: Route) -> None:
         if self.__chains.exists(stream):
@@ -326,11 +332,12 @@ class RustArroyoAdapter(StreamAdapter[Route, Route]):
             # Fix this to wrap the actual step instead of just the object_generator.
             # This will at least capture the number of calls to the step, if nothing else.
             def wrapped_generator() -> str:
-                start_time = input_metrics(step.name, None)
+                start_time = time.time()
+                input_metrics(step.name, self.__metrics_sample_rate)
                 try:
                     return step.object_generator()
                 finally:
-                    output_metrics(step.name, None, start_time, None)
+                    output_metrics(step.name, None, start_time, self.__metrics_sample_rate)
 
             logger.info(f"Adding GCS sink: {step.name} to pipeline")
             self.__consumers[stream.source].add_step(
@@ -381,7 +388,7 @@ class RustArroyoAdapter(StreamAdapter[Route, Route]):
         application_function = step.resolved_function
 
         wrapped_function = functools.partial(
-            _metrics_wrapped_function, step.name, application_function
+            _metrics_wrapped_function, step.name, self.__metrics_sample_rate, application_function
         )
 
         step = replace(step, function=wrapped_function)
@@ -450,18 +457,17 @@ class RustArroyoAdapter(StreamAdapter[Route, Route]):
         elif isinstance(step, PredicateFilter):
 
             def filter_msg(msg: Message[Any]) -> bool:
-                msg_size = get_size(msg.payload) if hasattr(msg, "payload") else None
-                start_time = input_metrics(step.name, msg_size)
-                has_error = output_size = None
+                input_metrics(step.name, self.__metrics_sample_rate)
+                has_error = None
+                start_time = time.time()
                 try:
                     result = step.resolved_function(msg)
-                    output_size = get_size(result)
                     return result
                 except Exception as e:
                     has_error = str(e.__class__.__name__)
                     raise e
                 finally:
-                    output_metrics(step.name, has_error, start_time, output_size)
+                    output_metrics(step.name, has_error, start_time, self.__metrics_sample_rate)
 
             self.__consumers[stream.source].add_step(RuntimeOperator.Filter(route, filter_msg))
             return stream
@@ -537,8 +543,8 @@ class RustArroyoAdapter(StreamAdapter[Route, Route]):
         route = RustRoute(stream.source, stream.waypoints)
 
         def routing_function(msg: Message[Any]) -> str:
-            msg_size = get_size(msg.payload) if hasattr(msg, "payload") else None
-            start_time = input_metrics(step.name, msg_size)
+            input_metrics(step.name, self.__metrics_sample_rate)
+            start_time = time.time()
             has_error = None
             try:
                 waypoint = step.routing_function(msg)
@@ -548,7 +554,7 @@ class RustArroyoAdapter(StreamAdapter[Route, Route]):
                 has_error = str(e.__class__.__name__)
                 raise e
             finally:
-                output_metrics(step.name, has_error, start_time, None)
+                output_metrics(step.name, has_error, start_time, self.__metrics_sample_rate)
 
         logger.info(f"Adding router: {step.name} to pipeline")
         self.__consumers[stream.source].add_step(

--- a/sentry_streams/sentry_streams/deployment_config/simple_map_filter.yaml
+++ b/sentry_streams/sentry_streams/deployment_config/simple_map_filter.yaml
@@ -8,6 +8,7 @@ pipeline:
   adapter_config:
     arroyo:
       write_healthcheck: true
+      metrics_sample_rate: 0.01
   segments:
     - steps_config:
         myinput:

--- a/sentry_streams/sentry_streams/metrics/metrics.py
+++ b/sentry_streams/sentry_streams/metrics/metrics.py
@@ -432,7 +432,7 @@ class ArroyoMetricsBackend:
         self.__backend.timing(name, value, tags=_tags_from_mapping(tags))
 
 
-_metrics_backend: Optional[MetricsBackend] = None
+_metrics: Optional[Metrics] = None
 _dummy_metrics_backend = DummyMetricsBackend()
 
 
@@ -458,22 +458,25 @@ def configure_metrics(config: MetricsConfig, force: bool = False) -> None:
     ``config.json``) so worker processes can rebuild the same backends under
     ``spawn`` multiprocessing.
     """
-    global _metrics_backend
+    global _metrics
     if not force:
-        assert _metrics_backend is None, "Metrics is already set"
+        assert _metrics is None, "Metrics is already set"
 
     inner = build_metrics_backend(config)
-    _metrics_backend = BufferedMetricsBackend(
+    backend = BufferedMetricsBackend(
         inner,
         throttle_interval_sec=_buffer_throttle_interval_sec(config),
     )
-    arroyo_configure_metrics(ArroyoMetricsBackend(_metrics_backend))
+    _metrics = Metrics(backend)
+    arroyo_configure_metrics(ArroyoMetricsBackend(backend))
 
 
 def get_metrics() -> Metrics:
-    if _metrics_backend is None:
-        return Metrics(_dummy_metrics_backend)
-    return Metrics(_metrics_backend)
+    global _metrics
+    if _metrics is None:
+        _metrics = Metrics(_dummy_metrics_backend)
+
+    return _metrics
 
 
 def get_size(obj: Any) -> int | None:


### PR DESCRIPTION
Recording metrics at every step is still having a major impact on throughput.

In this profile we ran the protobuf parsing of a message + metrics + message instantiation 1M times:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)                                                                                    
  1000000    1.957    0.000   12.888    0.000 /Users/filippopacifici/code/streams/sentry_streams/sentry_streams/adapters/arroyo/steps_chain.py:55(fake_transform)                                                                                                                                                     
  1000000    0.867    0.000    5.923    0.000 /Users/filippopacifici/code/streams/sentry_streams/sentry_streams/adapters/arroyo/steps_chain.py:34(output_metrics)                                                                                                                                                     
  1199970    0.442    0.000    2.962    0.000 /Users/filippopacifici/code/streams/sentry_streams/sentry_streams/metrics/metrics.py:380(increment)          
  1000000    0.510    0.000    2.678    0.000 /Users/filippopacifici/code/streams/sentry_streams/sentry_streams/pipeline/msg_codecs.py:45(msg_parser)      
  2199970    0.779    0.000    2.567    0.000 /Users/filippopacifici/code/streams/sentry_streams/sentry_streams/metrics/metrics.py:302(__add_to_buffer)    
  1000000    0.363    0.000    2.430    0.000 /Users/filippopacifici/code/streams/sentry_streams/sentry_streams/metrics/metrics.py:397(timing)             
  1199970    0.450    0.000    2.192    0.000 /Users/filippopacifici/code/streams/sentry_streams/sentry_streams/metrics/metrics.py:326(increment)          
  1000000    0.374    0.000    1.800    0.000 /Users/filippopacifici/code/streams/sentry_streams/sentry_streams/metrics/metrics.py:339(timing)             
  2199970    1.190    0.000    1.787    0.000 /Users/filippopacifici/code/streams/sentry_streams/sentry_streams/metrics/metrics.py:319(__hash_tags)        
  1000000    0.325    0.000    1.294    0.000 /Users/filippopacifici/code/streams/sentry_streams/.venv/lib/python3.11/site-packages/sentry_kafka_schemas/codecs/protobuf.py:34(decode)                                                                                                                                
  1000000    0.970    0.000    0.970    0.000 {method 'ParseFromString' of 'google._upb._message.Message' objects}                                         
  1000000    0.279    0.000    0.853    0.000 /Users/filippopacifici/code/streams/sentry_streams/sentry_streams/adapters/arroyo/steps_chain.py:20(input_metrics)                                                                                                                                                      
  1000000    0.503    0.000    0.805    0.000 /Users/filippopacifici/code/streams/sentry_streams/sentry_streams/pipeline/msg_codecs.py:32(_get_codec_from_msg)                                   
  2000000    0.493    0.000    0.744    0.000 /Users/filippopacifici/code/streams/sentry_streams/sentry_streams/metrics/metrics.py:488(get_size)
  2199970    0.454    0.000    0.601    0.000 /Users/filippopacifici/code/streams/sentry_streams/sentry_streams/metrics/metrics.py:343(__throttled_flush)
  2199970    0.450    0.000    0.595    0.000 /opt/homebrew/Cellar/python@3.11/3.11.9_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/enum.py:193(__get__)                            
  2199970    0.370    0.000    0.370    0.000 /Users/filippopacifici/code/streams/sentry_streams/sentry_streams/metrics/metrics.py:320(<listcomp>)
  3000555    0.271    0.000    0.271    0.000 {built-in method builtins.isinstance}
  1000000    0.177    0.000    0.249    0.000 {built-in method builtins.hasattr}
  3299957    0.222    0.000    0.222    0.000 {built-in method time.time}
  3000000    0.209    0.000    0.209    0.000 /Users/filippopacifici/code/streams/sentry_streams/sentry_streams/pipeline/message.py:201(payload)
  1000000    0.173    0.000    0.173    0.000 /Users/filippopacifici/code/streams/sentry_streams/sentry_streams/pipeline/message.py:105(__init__)
  2000000    0.166    0.000    0.166    0.000 /Users/filippopacifici/code/streams/sentry_streams/sentry_streams/pipeline/message.py:213(schema)
  1000000    0.161    0.000    0.163    0.000 /Users/filippopacifici/code/streams/sentry_streams/.venv/lib/python3.11/site-packages/sentry_kafka_schemas/sentry_kafka_schemas.py:147(get_codec)
  2199970    0.145    0.000    0.145    0.000 /opt/homebrew/Cellar/python@3.11/3.11.9_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/enum.py:12
```

3/4 of the time is spent in recording metrics in the buffered backend. 
This does not include sending the metrics, jsut the buffering logic.

This is not unexpected:
- we record metrics at each step and step logic can be minimal, even less than recording metrics.
- we record 5 metrics per step

In this PR:
- Reduced the number of metrics we record at each step. We can introduce something again later
- Introduced sampling so that we run the metrics logic a lot less

