### PR TITLE
fix(streams): correct Kafka timestamp scale for watermark commit latency

### DIFF
--- a/sentry_streams/src/consumer.rs
+++ b/sentry_streams/src/consumer.rs
@@ -257,7 +257,7 @@ fn to_routed_value(
     };
     // Convert message.timestamp() (Option<i64>) to UTC timestamp as float (seconds since epoch)
     let timestamp = match message.timestamp() {
-        Some(ts) => ts.timestamp_millis() as f64 / 1_000_000_000.0,
+        Some(ts) => ts.timestamp_millis() as f64 / 1000.0,
         None => 0.0, // Default to 0 if no timestamp is available
     };
     let raw_message = RawMessage {


### PR DESCRIPTION
## Summary

`to_routed_value` converted broker timestamps with `timestamp_millis() / 1_000_000_000.0` instead of `/ 1000.0`, so `RawMessage.timestamp` (and thus watermark `last_message_time`) was six orders of magnitude too small. The commit latency histogram subtracts that from `current_epoch()` (seconds), so samples clustered around ~1.78e9 (roughly “now”) instead of real end-to-end lag.

## Test plan

- `./sentry_streams/.venv/bin/pre-commit run --files sentry_streams/src/consumer.rs`
- `CMAKE_ARGS=-DCMAKE_POLICY_VERSION_MINIMUM=3.5` (and same in env) `cargo test` in `sentry_streams/`
- `make tests-streams`


Made with [Cursor](https://cursor.com)