### PR TITLE
Make binary smaller

### DIFF
--- a/sentry_streams/Cargo.toml
+++ b/sentry_streams/Cargo.toml
@@ -39,13 +39,3 @@ cli = ["dep:clap", "pyo3/auto-initialize"]
 [dev-dependencies]
 parking_lot = "0.12.1"
 pyo3 = { version = "*", features = ["auto-initialize"] }
-
-# For now (while we are still rolling out streams to SBC), let's enable maximal
-# debug information. There should only be overhead in space and when many
-# stacktraces are generated (thousands/sec)
-#
-# Later we can decide if we need to save storage. Snuba runs with less detailed
-# debuginfo.
-[profile.release]
-debug = true
-strip = false


### PR DESCRIPTION
We ran out of space on pypi :D.
This was mostly due to the fact that wheels are 50Mb because of the symbols
