### PR TITLE
fix(operator): do not use sha for version

### DIFF
--- a/.github/workflows/build-operator.yaml
+++ b/.github/workflows/build-operator.yaml
@@ -49,7 +49,6 @@ jobs:
       contents: write
     env:
       CHART_DIR: sentry_streams_k8s/chart/streaming-operator
-      CHART_VERSION: 0.0.0-${{ github.sha }}
       IMAGE_TAG: ${{ github.sha }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -58,6 +57,7 @@ jobs:
 
       - name: Prepare and lint chart
         run: |
+          CHART_VERSION="0.0.$(git rev-list --count HEAD)"
           sed -i "s/^version:.*/version: ${CHART_VERSION}/" "${CHART_DIR}/Chart.yaml"
           sed -i "s/^appVersion:.*/appVersion: \"${IMAGE_TAG}\"/" "${CHART_DIR}/Chart.yaml"
           helm lint "${CHART_DIR}" --set workloadNamespace=streaming-pipelines


### PR DESCRIPTION
Using the SHA hash marks the chart as a pre-release version, so we use commit count instead to version it as some increasing number (doesn't really matter, just that it is increasing and in the form `X.Y.Z` with no suffix).