### PR TITLE
ref(operator): extract reconcile and use generated clients

### DIFF
--- a/sentry_streams_k8s/sentry_streams_k8s/operator/constants.py
+++ b/sentry_streams_k8s/sentry_streams_k8s/operator/constants.py
@@ -7,6 +7,11 @@ PLURAL = "streamingpipelines"
 FIELD_MANAGER = "streaming-operator"
 WORKLOAD_NAMESPACE_ENV = "WORKLOAD_NAMESPACE"
 
+# SSA through API clients is tagged with the _content_type
+# override and is required to keep tracking field ownership.
+
+APPLY_PATCH_CONTENT_TYPE = "application/apply-patch+yaml"
+
 # The CR and its workloads may live in different namespaces, so we cannot use
 # ownerReferences (Kubernetes forbids cross-namespace owning) or kopf.adopt.
 # Instead every workload carries the owning CR's UID as a label with

--- a/sentry_streams_k8s/sentry_streams_k8s/operator/constants.py
+++ b/sentry_streams_k8s/sentry_streams_k8s/operator/constants.py
@@ -17,6 +17,6 @@ APPLY_PATCH_CONTENT_TYPE = "application/apply-patch+yaml"
 # Instead every workload carries the owning CR's UID as a label with
 # name/namespace annotations so the operator can delete resources itself:
 
-OWNER_UID_LABEL = "streams.sentry.io/owner-uid"
-OWNER_NAME_ANNOTATION = "streams.sentry.io/owner-name"
-OWNER_NAMESPACE_ANNOTATION = "streams.sentry.io/owner-namespace"
+OWNER_UID_LABEL = "pipeline.streams.sentry.io/owner-uid"
+OWNER_NAME_ANNOTATION = "pipeline.streams.sentry.io/owner-name"
+OWNER_NAMESPACE_ANNOTATION = "pipeline.streams.sentry.io/owner-namespace"

--- a/sentry_streams_k8s/sentry_streams_k8s/operator/constants.py
+++ b/sentry_streams_k8s/sentry_streams_k8s/operator/constants.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+GROUP = "streams.sentry.io"
+VERSION = "v1alpha1"
+PLURAL = "streamingpipelines"
+
+FIELD_MANAGER = "streaming-operator"
+WORKLOAD_NAMESPACE_ENV = "WORKLOAD_NAMESPACE"
+
+# The CR and its workloads may live in different namespaces, so we cannot use
+# ownerReferences (Kubernetes forbids cross-namespace owning) or kopf.adopt.
+# Instead every workload carries the owning CR's UID as a label with
+# name/namespace annotations so the operator can delete resources itself:
+
+OWNER_UID_LABEL = "streams.sentry.io/owner-uid"
+OWNER_NAME_ANNOTATION = "streams.sentry.io/owner-name"
+OWNER_NAMESPACE_ANNOTATION = "streams.sentry.io/owner-namespace"

--- a/sentry_streams_k8s/sentry_streams_k8s/operator/operator.py
+++ b/sentry_streams_k8s/sentry_streams_k8s/operator/operator.py
@@ -1,30 +1,20 @@
 from __future__ import annotations
 
-import logging
 import os
 from typing import Any
 
 import kopf
-from kubernetes import client, dynamic
-from kubernetes.client.exceptions import ApiException
 
-from sentry_streams_k8s.consumer_builder import compute_config_version
-from sentry_streams_k8s.operator.streaming_pipeline import (
-    from_crd_spec,
-    render,
-    validate,
+from sentry_streams_k8s.operator.constants import (
+    GROUP,
+    PLURAL,
+    VERSION,
+    WORKLOAD_NAMESPACE_ENV,
 )
-
-logger = logging.getLogger(__name__)
-
-GROUP = "streams.sentry.io"
-VERSION = "v1alpha1"
-PLURAL = "streamingpipelines"
-FIELD_MANAGER = "streaming-operator"
-WORKLOAD_NAMESPACE_ENV = "WORKLOAD_NAMESPACE"
-OWNER_UID_LABEL = "streams.sentry.io/owner-uid"
-OWNER_NAME_ANNOTATION = "streams.sentry.io/owner-name"
-OWNER_NAMESPACE_ANNOTATION = "streams.sentry.io/owner-namespace"
+from sentry_streams_k8s.operator.reconcile import (
+    _prune_stale_resources,
+    reconcile_pipeline,
+)
 
 
 def _workload_namespace() -> str:
@@ -32,112 +22,6 @@ def _workload_namespace() -> str:
     if not namespace:
         raise RuntimeError(f"{WORKLOAD_NAMESPACE_ENV} must be set.")
     return namespace
-
-
-def _prepare_manifest(
-    manifest: dict[str, Any],
-    *,
-    workload_namespace: str,
-    owner_uid: str,
-    owner_name: str,
-    owner_namespace: str,
-) -> None:
-    metadata = manifest.setdefault("metadata", {})
-    metadata["namespace"] = workload_namespace
-    metadata["labels"] = {
-        **metadata.get("labels", {}),
-        OWNER_UID_LABEL: owner_uid,
-    }
-    metadata["annotations"] = {
-        **metadata.get("annotations", {}),
-        OWNER_NAME_ANNOTATION: owner_name,
-        OWNER_NAMESPACE_ANNOTATION: owner_namespace,
-    }
-
-
-def _apply(
-    dyn: dynamic.DynamicClient,
-    manifest: dict[str, Any],
-    *,
-    workload_namespace: str,
-    owner_uid: str,
-) -> None:
-    resource = dyn.resources.get(api_version=manifest["apiVersion"], kind=manifest["kind"])
-    name = manifest["metadata"]["name"]
-    try:
-        existing = resource.get(name=name, namespace=workload_namespace)
-    except ApiException as e:
-        if e.status != 404:
-            raise
-    else:
-        labels = existing.metadata.labels or {}
-        existing_owner_uid = labels.get(OWNER_UID_LABEL)
-        if existing_owner_uid != owner_uid:
-            raise kopf.PermanentError(
-                f"{manifest['kind']} {workload_namespace}/{name} is already present and is not "
-                "managed by this StreamingPipeline."
-            )
-
-    dyn.server_side_apply(
-        resource,
-        body=manifest,
-        namespace=workload_namespace,
-        field_manager=FIELD_MANAGER,
-        force_conflicts=True,
-    )
-
-
-def _prune_stale_resources(
-    *,
-    workload_namespace: str,
-    owner_uid: str,
-    desired_deployments: set[str],
-    desired_configmaps: set[str],
-) -> None:
-    selector = f"{OWNER_UID_LABEL}={owner_uid}"
-
-    apps = client.AppsV1Api()
-    deployments = apps.list_namespaced_deployment(
-        namespace=workload_namespace,
-        label_selector=selector,
-    )
-    for deployment in deployments.items:
-        if deployment.metadata.name not in desired_deployments:
-            logger.info(
-                "Pruning stale deployment %s/%s",
-                workload_namespace,
-                deployment.metadata.name,
-            )
-            apps.delete_namespaced_deployment(
-                name=deployment.metadata.name,
-                namespace=workload_namespace,
-            )
-
-    core = client.CoreV1Api()
-    configmaps = core.list_namespaced_config_map(
-        namespace=workload_namespace,
-        label_selector=selector,
-    )
-    for configmap in configmaps.items:
-        if configmap.metadata.name not in desired_configmaps:
-            logger.info(
-                "Pruning stale configmap %s/%s",
-                workload_namespace,
-                configmap.metadata.name,
-            )
-            core.delete_namespaced_config_map(
-                name=configmap.metadata.name,
-                namespace=workload_namespace,
-            )
-
-
-def _condition(type_: str, status: bool, reason: str, message: str = "") -> dict[str, Any]:
-    return {
-        "type": type_,
-        "status": "True" if status else "False",
-        "reason": reason,
-        "message": message,
-    }
 
 
 @kopf.on.create(GROUP, VERSION, PLURAL)
@@ -152,60 +36,14 @@ def reconcile(
     **_: Any,
 ) -> None:
     assert namespace is not None
-    workload_namespace = _workload_namespace()
-
-    consumer = from_crd_spec(dict(spec), name=name)
-    try:
-        validate(consumer)
-        result = render(consumer)
-    except Exception as e:
-        patch.status["conditions"] = [_condition("Rendered", False, type(e).__name__, str(e))]
-        raise kopf.PermanentError(f"StreamingPipeline {namespace}/{name} failed to render: {e}")
-
-    manifests = [result["configmap"], result["deployment"]]
-    if "canary_deployment" in result:
-        manifests.append(result["canary_deployment"])
-
-    dyn = dynamic.DynamicClient(client.ApiClient())
-    for manifest in manifests:
-        _prepare_manifest(
-            manifest,
-            workload_namespace=workload_namespace,
-            owner_uid=uid,
-            owner_name=name,
-            owner_namespace=namespace,
-        )
-        _apply(
-            dyn,
-            manifest,
-            workload_namespace=workload_namespace,
-            owner_uid=uid,
-        )
-
-    _prune_stale_resources(
-        workload_namespace=workload_namespace,
-        owner_uid=uid,
-        desired_deployments={
-            manifest["metadata"]["name"]
-            for manifest in manifests
-            if manifest["kind"] == "Deployment"
-        },
-        desired_configmaps={
-            manifest["metadata"]["name"]
-            for manifest in manifests
-            if manifest["kind"] == "ConfigMap"
-        },
+    reconcile_pipeline(
+        spec=spec,
+        name=name,
+        namespace=namespace,
+        uid=uid,
+        workload_namespace=_workload_namespace(),
+        patch=patch,
     )
-
-    replicas = consumer.get("replicas", 1)
-    canary = 1 if "canary_deployment" in result else 0
-    patch.status["conditions"] = [
-        _condition("Rendered", True, "Rendered"),
-        _condition("Applied", True, "Applied"),
-    ]
-    patch.status["config_version"] = compute_config_version(consumer["pipeline_config"])
-    patch.status["replicas"] = {"primary": replicas - canary, "canary": canary}
-    patch.status["workload_namespace"] = workload_namespace
 
 
 @kopf.on.delete(GROUP, VERSION, PLURAL)

--- a/sentry_streams_k8s/sentry_streams_k8s/operator/reconcile.py
+++ b/sentry_streams_k8s/sentry_streams_k8s/operator/reconcile.py
@@ -4,11 +4,11 @@ import logging
 from typing import Any
 
 import kopf
-from kubernetes import client, dynamic
-from kubernetes.client.exceptions import ApiException
+from kubernetes import client
 
 from sentry_streams_k8s.consumer_builder import compute_config_version
 from sentry_streams_k8s.operator.constants import (
+    APPLY_PATCH_CONTENT_TYPE,
     FIELD_MANAGER,
     OWNER_NAME_ANNOTATION,
     OWNER_NAMESPACE_ANNOTATION,
@@ -44,35 +44,35 @@ def _prepare_manifest(
     }
 
 
-def _apply(
-    dyn: dynamic.DynamicClient,
+def _apply_configmap(
+    core: client.CoreV1Api,
     manifest: dict[str, Any],
     *,
     workload_namespace: str,
-    owner_uid: str,
 ) -> None:
-    resource = dyn.resources.get(api_version=manifest["apiVersion"], kind=manifest["kind"])
-    name = manifest["metadata"]["name"]
-    try:
-        existing = resource.get(name=name, namespace=workload_namespace)
-    except ApiException as e:
-        if e.status != 404:
-            raise
-    else:
-        labels = existing.metadata.labels or {}
-        existing_owner_uid = labels.get(OWNER_UID_LABEL)
-        if existing_owner_uid != owner_uid:
-            raise kopf.PermanentError(
-                f"{manifest['kind']} {workload_namespace}/{name} is already present and is not "
-                "managed by this StreamingPipeline."
-            )
-
-    dyn.server_side_apply(
-        resource,
-        body=manifest,
+    core.patch_namespaced_config_map(
+        name=manifest["metadata"]["name"],
         namespace=workload_namespace,
+        body=manifest,
         field_manager=FIELD_MANAGER,
-        force_conflicts=True,
+        force=True,
+        _content_type=APPLY_PATCH_CONTENT_TYPE,
+    )
+
+
+def _apply_deployment(
+    apps: client.AppsV1Api,
+    manifest: dict[str, Any],
+    *,
+    workload_namespace: str,
+) -> None:
+    apps.patch_namespaced_deployment(
+        name=manifest["metadata"]["name"],
+        namespace=workload_namespace,
+        body=manifest,
+        field_manager=FIELD_MANAGER,
+        force=True,
+        _content_type=APPLY_PATCH_CONTENT_TYPE,
     )
 
 
@@ -150,7 +150,9 @@ def reconcile_pipeline(
     if "canary_deployment" in result:
         manifests.append(result["canary_deployment"])
 
-    dyn = dynamic.DynamicClient(client.ApiClient())
+    core = client.CoreV1Api()
+    apps = client.AppsV1Api()
+
     for manifest in manifests:
         _prepare_manifest(
             manifest,
@@ -159,12 +161,13 @@ def reconcile_pipeline(
             owner_name=name,
             owner_namespace=namespace,
         )
-        _apply(
-            dyn,
-            manifest,
-            workload_namespace=workload_namespace,
-            owner_uid=uid,
-        )
+        kind = manifest["kind"]
+        if kind == "ConfigMap":
+            _apply_configmap(core, manifest, workload_namespace=workload_namespace)
+        elif kind == "Deployment":
+            _apply_deployment(apps, manifest, workload_namespace=workload_namespace)
+        else:
+            raise kopf.PermanentError(f"Cannot apply unsupported manifest kind {kind}.")
 
     _prune_stale_resources(
         workload_namespace=workload_namespace,

--- a/sentry_streams_k8s/sentry_streams_k8s/operator/reconcile.py
+++ b/sentry_streams_k8s/sentry_streams_k8s/operator/reconcile.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import kopf
+from kubernetes import client, dynamic
+from kubernetes.client.exceptions import ApiException
+
+from sentry_streams_k8s.consumer_builder import compute_config_version
+from sentry_streams_k8s.operator.constants import (
+    FIELD_MANAGER,
+    OWNER_NAME_ANNOTATION,
+    OWNER_NAMESPACE_ANNOTATION,
+    OWNER_UID_LABEL,
+)
+from sentry_streams_k8s.operator.streaming_pipeline import (
+    from_crd_spec,
+    render,
+    validate,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _prepare_manifest(
+    manifest: dict[str, Any],
+    *,
+    workload_namespace: str,
+    owner_uid: str,
+    owner_name: str,
+    owner_namespace: str,
+) -> None:
+    metadata = manifest.setdefault("metadata", {})
+    metadata["namespace"] = workload_namespace
+    metadata["labels"] = {
+        **metadata.get("labels", {}),
+        OWNER_UID_LABEL: owner_uid,
+    }
+    metadata["annotations"] = {
+        **metadata.get("annotations", {}),
+        OWNER_NAME_ANNOTATION: owner_name,
+        OWNER_NAMESPACE_ANNOTATION: owner_namespace,
+    }
+
+
+def _apply(
+    dyn: dynamic.DynamicClient,
+    manifest: dict[str, Any],
+    *,
+    workload_namespace: str,
+    owner_uid: str,
+) -> None:
+    resource = dyn.resources.get(api_version=manifest["apiVersion"], kind=manifest["kind"])
+    name = manifest["metadata"]["name"]
+    try:
+        existing = resource.get(name=name, namespace=workload_namespace)
+    except ApiException as e:
+        if e.status != 404:
+            raise
+    else:
+        labels = existing.metadata.labels or {}
+        existing_owner_uid = labels.get(OWNER_UID_LABEL)
+        if existing_owner_uid != owner_uid:
+            raise kopf.PermanentError(
+                f"{manifest['kind']} {workload_namespace}/{name} is already present and is not "
+                "managed by this StreamingPipeline."
+            )
+
+    dyn.server_side_apply(
+        resource,
+        body=manifest,
+        namespace=workload_namespace,
+        field_manager=FIELD_MANAGER,
+        force_conflicts=True,
+    )
+
+
+def _prune_stale_resources(
+    *,
+    workload_namespace: str,
+    owner_uid: str,
+    desired_deployments: set[str],
+    desired_configmaps: set[str],
+) -> None:
+    selector = f"{OWNER_UID_LABEL}={owner_uid}"
+
+    apps = client.AppsV1Api()
+    deployments = apps.list_namespaced_deployment(
+        namespace=workload_namespace,
+        label_selector=selector,
+    )
+    for deployment in deployments.items:
+        if deployment.metadata.name not in desired_deployments:
+            logger.info(
+                "Pruning stale deployment %s/%s",
+                workload_namespace,
+                deployment.metadata.name,
+            )
+            apps.delete_namespaced_deployment(
+                name=deployment.metadata.name,
+                namespace=workload_namespace,
+            )
+
+    core = client.CoreV1Api()
+    configmaps = core.list_namespaced_config_map(
+        namespace=workload_namespace,
+        label_selector=selector,
+    )
+    for configmap in configmaps.items:
+        if configmap.metadata.name not in desired_configmaps:
+            logger.info(
+                "Pruning stale configmap %s/%s",
+                workload_namespace,
+                configmap.metadata.name,
+            )
+            core.delete_namespaced_config_map(
+                name=configmap.metadata.name,
+                namespace=workload_namespace,
+            )
+
+
+def _condition(type_: str, status: bool, reason: str, message: str = "") -> dict[str, Any]:
+    return {
+        "type": type_,
+        "status": "True" if status else "False",
+        "reason": reason,
+        "message": message,
+    }
+
+
+def reconcile_pipeline(
+    *,
+    spec: Any,
+    name: str,
+    namespace: str,
+    uid: str,
+    workload_namespace: str,
+    patch: kopf.Patch,
+) -> None:
+    consumer = from_crd_spec(dict(spec), name=name)
+    try:
+        validate(consumer)
+        result = render(consumer)
+    except Exception as e:
+        patch.status["conditions"] = [_condition("Rendered", False, type(e).__name__, str(e))]
+        raise kopf.PermanentError(f"StreamingPipeline {namespace}/{name} failed to render: {e}")
+
+    manifests = [result["configmap"], result["deployment"]]
+    if "canary_deployment" in result:
+        manifests.append(result["canary_deployment"])
+
+    dyn = dynamic.DynamicClient(client.ApiClient())
+    for manifest in manifests:
+        _prepare_manifest(
+            manifest,
+            workload_namespace=workload_namespace,
+            owner_uid=uid,
+            owner_name=name,
+            owner_namespace=namespace,
+        )
+        _apply(
+            dyn,
+            manifest,
+            workload_namespace=workload_namespace,
+            owner_uid=uid,
+        )
+
+    _prune_stale_resources(
+        workload_namespace=workload_namespace,
+        owner_uid=uid,
+        desired_deployments={
+            manifest["metadata"]["name"]
+            for manifest in manifests
+            if manifest["kind"] == "Deployment"
+        },
+        desired_configmaps={
+            manifest["metadata"]["name"]
+            for manifest in manifests
+            if manifest["kind"] == "ConfigMap"
+        },
+    )
+
+    replicas = consumer.get("replicas", 1)
+    canary = 1 if "canary_deployment" in result else 0
+    patch.status["conditions"] = [
+        _condition("Rendered", True, "Rendered"),
+        _condition("Applied", True, "Applied"),
+    ]
+    patch.status["config_version"] = compute_config_version(consumer["pipeline_config"])
+    patch.status["replicas"] = {"primary": replicas - canary, "canary": canary}
+    patch.status["workload_namespace"] = workload_namespace

--- a/sentry_streams_k8s/tests/test_operator.py
+++ b/sentry_streams_k8s/tests/test_operator.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
-
-import kopf
-import pytest
 
 from sentry_streams_k8s.operator.constants import (
     OWNER_NAME_ANNOTATION,
@@ -12,7 +10,9 @@ from sentry_streams_k8s.operator.constants import (
     OWNER_UID_LABEL,
 )
 from sentry_streams_k8s.operator.reconcile import (
-    _apply,
+    APPLY_PATCH_CONTENT_TYPE,
+    _apply_configmap,
+    _apply_deployment,
     _prepare_manifest,
     _prune_stale_resources,
 )
@@ -55,57 +55,51 @@ def test_prepare_manifest_routes_workload_and_records_source_cr() -> None:
     }
 
 
-def test_apply_rejects_resource_owned_by_another_cr() -> None:
-    resource = MagicMock()
-    resource.get.return_value = SimpleNamespace(
-        metadata=SimpleNamespace(labels={OWNER_UID_LABEL: "another-owner"})
-    )
-    dyn = MagicMock()
-    dyn.resources.get.return_value = resource
-    manifest = {
+def _configmap_manifest() -> dict[str, Any]:
+    return {
         "apiVersion": "v1",
         "kind": "ConfigMap",
         "metadata": {"name": "pipeline", "namespace": WORKLOAD_NAMESPACE},
     }
 
-    with pytest.raises(kopf.PermanentError, match="not managed by this StreamingPipeline"):
-        _apply(
-            dyn,
-            manifest,
-            workload_namespace=WORKLOAD_NAMESPACE,
-            owner_uid="owner-uid",
-        )
 
-    dyn.server_side_apply.assert_not_called()
-
-
-def test_apply_uses_workload_namespace_and_stable_field_manager() -> None:
-    resource = MagicMock()
-    resource.get.return_value = SimpleNamespace(
-        metadata=SimpleNamespace(labels={OWNER_UID_LABEL: "owner-uid"})
-    )
-    dyn = MagicMock()
-    dyn.resources.get.return_value = resource
-    manifest = {
-        "apiVersion": "v1",
-        "kind": "ConfigMap",
+def _deployment_manifest() -> dict[str, Any]:
+    return {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
         "metadata": {"name": "pipeline", "namespace": WORKLOAD_NAMESPACE},
     }
 
-    _apply(
-        dyn,
-        manifest,
-        workload_namespace=WORKLOAD_NAMESPACE,
-        owner_uid="owner-uid",
-    )
 
-    resource.get.assert_called_once_with(name="pipeline", namespace=WORKLOAD_NAMESPACE)
-    dyn.server_side_apply.assert_called_once_with(
-        resource,
-        body=manifest,
+def test_apply_configmap() -> None:
+    core = MagicMock()
+    manifest = _configmap_manifest()
+
+    _apply_configmap(core, manifest, workload_namespace=WORKLOAD_NAMESPACE)
+
+    core.patch_namespaced_config_map.assert_called_once_with(
+        name="pipeline",
         namespace=WORKLOAD_NAMESPACE,
+        body=manifest,
         field_manager="streaming-operator",
-        force_conflicts=True,
+        force=True,
+        _content_type=APPLY_PATCH_CONTENT_TYPE,
+    )
+
+
+def test_apply_deployment() -> None:
+    apps = MagicMock()
+    manifest = _deployment_manifest()
+
+    _apply_deployment(apps, manifest, workload_namespace=WORKLOAD_NAMESPACE)
+
+    apps.patch_namespaced_deployment.assert_called_once_with(
+        name="pipeline",
+        namespace=WORKLOAD_NAMESPACE,
+        body=manifest,
+        field_manager="streaming-operator",
+        force=True,
+        _content_type=APPLY_PATCH_CONTENT_TYPE,
     )
 
 

--- a/sentry_streams_k8s/tests/test_operator.py
+++ b/sentry_streams_k8s/tests/test_operator.py
@@ -6,10 +6,12 @@ from unittest.mock import MagicMock, patch
 import kopf
 import pytest
 
-from sentry_streams_k8s.operator.operator import (
+from sentry_streams_k8s.operator.constants import (
     OWNER_NAME_ANNOTATION,
     OWNER_NAMESPACE_ANNOTATION,
     OWNER_UID_LABEL,
+)
+from sentry_streams_k8s.operator.reconcile import (
     _apply,
     _prepare_manifest,
     _prune_stale_resources,
@@ -107,8 +109,8 @@ def test_apply_uses_workload_namespace_and_stable_field_manager() -> None:
     )
 
 
-@patch("sentry_streams_k8s.operator.operator.client.CoreV1Api")
-@patch("sentry_streams_k8s.operator.operator.client.AppsV1Api")
+@patch("sentry_streams_k8s.operator.reconcile.client.CoreV1Api")
+@patch("sentry_streams_k8s.operator.reconcile.client.AppsV1Api")
 def test_prune_removes_only_stale_resources(
     apps_api: MagicMock,
     core_api: MagicMock,


### PR DESCRIPTION
Avoid using DynamicClient and use the SSA patching with typed clients instead. Extracts reconcile behavior to separate modules to be expanded later.